### PR TITLE
Tonight에서 모델 목록을 뺀다

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -321,12 +321,12 @@ describe("App Overnight integration", () => {
     const { default: App } = await import("./App");
     render(<App />);
 
-    expect(await screen.findByRole("heading", { name: "Connect a conversation model to see tonight’s 3 cards" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Sign in with your Anthropic/ })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Tonight's 3 cards" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Sign in with your Anthropic/ })).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Overnight" }));
     expect(await screen.findByRole("heading", { name: "Connect a conversation model first" })).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Connect a model on Ask Morrow" }));
-    expect(screen.getByRole("heading", { name: "Connect a conversation model to see tonight’s 3 cards" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Tonight's 3 cards" })).toBeInTheDocument();
     expect(bridge.prepareOvernightPortfolio).not.toHaveBeenCalled();
   });
 

--- a/src/components/ChatView.test.tsx
+++ b/src/components/ChatView.test.tsx
@@ -228,7 +228,7 @@ describe("Morrow first-use conversation", () => {
   });
 
   it("puts conversation-model setup in the tonight region when Morrow has no voice", () => {
-    const onConnect = vi.fn(async () => undefined);
+    const onOpenSettings = vi.fn();
     render(
       <ChatView
         state={{
@@ -240,17 +240,18 @@ describe("Morrow first-use conversation", () => {
         onApproval={vi.fn()}
         onModel={vi.fn()}
         onThinking={vi.fn()}
-        onOpenSettings={vi.fn()}
+        onOpenSettings={onOpenSettings}
         onStartTonight={vi.fn(async () => undefined)}
-        onConnect={onConnect}
+        onConnect={vi.fn(async () => undefined)}
         onDisconnect={vi.fn(async () => undefined)}
         hasReadyOvernightWorker
       />,
     );
 
-    expect(screen.getByRole("region", { name: "Tonight's overnights" })).toHaveTextContent("Connect a conversation model to see tonight’s 3 cards");
-    fireEvent.click(screen.getByRole("button", { name: /Sign in with your Anthropic/ }));
-    expect(onConnect).toHaveBeenCalledWith("anthropic", "oauth");
+    expect(screen.getByRole("region", { name: "Tonight's overnights" })).toHaveTextContent("Tonight's 3 cards");
+    fireEvent.click(screen.getByRole("button", { name: "Connect a model in Settings" }));
+    expect(onOpenSettings).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("button", { name: /Sign in with your Anthropic/ })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Start / })).not.toBeInTheDocument();
   });
 

--- a/src/components/TonightPlan.test.tsx
+++ b/src/components/TonightPlan.test.tsx
@@ -81,7 +81,7 @@ describe("TonightPlan", () => {
   });
 
   it("puts conversation-model connect controls in the tonight region when Morrow has no voice", () => {
-    const onConnect = vi.fn(async () => undefined);
+    const onOpenSettings = vi.fn();
     render(
       <TonightPlan
         language="en"
@@ -103,14 +103,19 @@ describe("TonightPlan", () => {
             portfolioRuns: [],
           },
         }}
-        onConnect={onConnect}
+        onConnect={vi.fn(async () => undefined)}
         onDisconnect={vi.fn(async () => undefined)}
+        onOpenSettings={onOpenSettings}
       />,
     );
 
-    expect(screen.getByRole("heading", { name: "Connect a conversation model to see tonight’s 3 cards" })).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: /Sign in with your Anthropic/ }));
-    expect(onConnect).toHaveBeenCalledWith("anthropic", "oauth");
+    expect(screen.getByRole("heading", { name: "Tonight's 3 cards" })).toBeInTheDocument();
+    expect(screen.getByText("OVERNIGHT 1")).toBeInTheDocument();
+    expect(screen.getByText("OVERNIGHT 2")).toBeInTheDocument();
+    expect(screen.getByText("OVERNIGHT 3")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Sign in with your Anthropic/ })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Connect a model in Settings" }));
+    expect(onOpenSettings).toHaveBeenCalledOnce();
     expect(screen.queryByRole("button", { name: /Start / })).not.toBeInTheDocument();
   });
 });

--- a/src/components/TonightPlan.tsx
+++ b/src/components/TonightPlan.tsx
@@ -51,20 +51,23 @@ export function TonightPlan({
   };
 
   return (
-    <section className="tonight-plan mx-auto mb-6 w-full max-w-[720px] rounded-panel border border-line bg-surface/70 p-4 shadow-panel" aria-label={ko ? "오늘 밤 추천" : "Tonight's overnights"}>
-      <div className="mb-3 flex items-end justify-between gap-3">
-        <div>
+    <section className="tonight-plan mx-auto mb-3 w-full max-w-[820px]" aria-label={ko ? "오늘 밤 추천" : "Tonight's overnights"}>
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <div className="min-w-0">
           <span className="font-mono text-[9px] font-semibold tracking-[0.13em] text-amber">{ko ? "오늘 밤" : "TONIGHT"}</span>
-          <h2 className="mt-1 text-[17px] font-medium tracking-[-0.02em]">{tonightHeading({ ko, preparing, items, needsConversationModel, needsOvernightWorker })}</h2>
-          <p className="mt-1 text-[12px] leading-5 text-ink-muted">{tonightCopy({ ko, preparing, items, needsConversationModel, needsOvernightWorker })}</p>
+          <h2 className="text-[15px] font-medium tracking-[-0.02em]">{tonightHeading({ ko, preparing, items, needsConversationModel, needsOvernightWorker })}</h2>
+          <p className="text-[11px] leading-4 text-ink-muted">{tonightCopy({ ko, preparing, items, needsConversationModel, needsOvernightWorker })}</p>
         </div>
         {plan && items.length > 0 && (
           <Button variant="primary" className="min-h-11 shrink-0 px-5 text-sm" disabled={working || disabled || selectedIds.length === 0} onClick={() => void start()}>
             {working ? (ko ? "시작하는 중…" : "Starting…") : (ko ? `선택한 ${selectedIds.length}개 시작` : `Start ${selectedIds.length} selected`)}
           </Button>
         )}
+        {needsConversationModel && onOpenSettings && items.length === 0 ? (
+          <Button variant="primary" className="shrink-0" onClick={onOpenSettings}>{ko ? "설정에서 모델 연결" : "Connect a model in Settings"}</Button>
+        ) : null}
       </div>
-      <div className="grid gap-2">
+      <div className="grid grid-cols-3 gap-2">
         {items.length > 0
           ? items.map((item, index) => (
               <TonightCard key={item.id} index={index} item={item} checked={checked[item.id] !== false} ko={ko} onToggle={() => setChecked((current) => ({ ...current, [item.id]: current[item.id] === false }))} />
@@ -72,7 +75,7 @@ export function TonightPlan({
           : [0, 1, 2].map((index) => <EmptyTonightCard key={index} index={index} ko={ko} />)}
       </div>
       {needsConversationModel && onOpenSettings ? (
-        <Button variant="primary" className="mt-3" onClick={onOpenSettings}>{ko ? "설정에서 모델 연결" : "Connect a model in Settings"}</Button>
+        items.length > 0 ? <Button variant="primary" className="mt-3" onClick={onOpenSettings}>{ko ? "설정에서 모델 연결" : "Connect a model in Settings"}</Button> : null
       ) : needsOvernightWorker ? (
         <div className="mt-3 grid gap-2">
           <p className="text-[12px] leading-5 text-ink-muted">{ko ? "Claude Code, Codex, Grok Build, Pi Agent 중 하나를 이 Mac의 PATH에 두고 공식 CLI로 로그인하세요." : "Put Claude Code, Codex, Grok Build, or Pi Agent on this Mac’s PATH and sign in with that official CLI."}</p>
@@ -126,11 +129,9 @@ function tonightCopy({
 
 function EmptyTonightCard({ index, ko }: { index: number; ko: boolean }) {
   return (
-    <div className="flex gap-3 rounded-[12px] border border-line bg-surface-raised px-3.5 py-3">
-      <span className="min-w-0 flex-1">
-        <small className="font-mono text-[9px] tracking-[0.12em] text-ink-faint">{`OVERNIGHT ${index + 1}`}</small>
-        <strong className="mt-0.5 block text-[13px] leading-5">{ko ? "아직 비어 있음" : "Empty"}</strong>
-      </span>
+    <div className="min-h-[88px] rounded-[12px] border border-line bg-surface-raised px-3 py-3">
+      <small className="font-mono text-[9px] tracking-[0.12em] text-ink-faint">{`OVERNIGHT ${index + 1}`}</small>
+      <strong className="mt-0.5 block text-[13px] leading-5">{ko ? "아직 비어 있음" : "Empty"}</strong>
     </div>
   );
 }
@@ -143,14 +144,14 @@ function TonightCard({ item, index, checked, ko, onToggle }: {
   onToggle(): void;
 }) {
   return (
-    <label className={`flex cursor-pointer gap-3 rounded-[12px] border px-3.5 py-3 transition-[border-color,background-color,opacity] duration-150 ease-morrow ${checked ? "border-line bg-surface-raised" : "border-transparent bg-transparent opacity-55"}`}>
-      <input type="checkbox" className="mt-1 size-4 accent-amber" checked={checked} onChange={onToggle} />
-      <span className="min-w-0 flex-1">
+    <label className={`flex min-h-[88px] cursor-pointer flex-col rounded-[12px] border px-3 py-3 transition-[border-color,background-color,opacity] duration-150 ease-morrow ${checked ? "border-line bg-surface-raised" : "border-transparent bg-transparent opacity-55"}`}>
+      <span className="flex items-start justify-between gap-2">
         <small className="font-mono text-[9px] tracking-[0.12em] text-ink-faint">{`OVERNIGHT ${index + 1}`}</small>
-        <strong className="mt-0.5 block text-[13px] leading-5">{item.outcome}</strong>
-        <span className="mt-1 block text-[11px] text-ink-muted">{item.providerLabel}{item.providerReason ? ` · ${item.providerReason}` : ""}</span>
+        <input type="checkbox" className="mt-0.5 size-4 shrink-0 accent-amber" checked={checked} onChange={onToggle} />
       </span>
-      <span className="self-center font-mono text-[9px] text-ink-faint">{ko ? `${item.estimatedMinutes}분` : `${item.estimatedMinutes}m`}</span>
+      <strong className="mt-0.5 block text-[13px] leading-5">{item.outcome}</strong>
+      <span className="mt-1 block text-[11px] text-ink-muted">{item.providerLabel}{item.providerReason ? ` · ${item.providerReason}` : ""}</span>
+      <span className="mt-auto pt-1 font-mono text-[9px] text-ink-faint">{ko ? `${item.estimatedMinutes}분` : `${item.estimatedMinutes}m`}</span>
     </label>
   );
 }

--- a/src/components/TonightPlan.tsx
+++ b/src/components/TonightPlan.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import type { AppLanguage, BootstrapState, OvernightPortfolioPlanItemSummary, OvernightPortfolioPlanSummary } from "../shared/contracts";
 import { tonightPlanItems } from "../lib/tonight";
-import { ProviderConnections } from "./ProviderConnections";
 import { Button } from "./ui/Button";
 
 export function TonightPlan({
@@ -12,9 +11,6 @@ export function TonightPlan({
   onStart,
   needsConversationModel,
   needsOvernightWorker,
-  state,
-  onConnect,
-  onDisconnect,
   onOpenSettings,
 }: {
   plan?: OvernightPortfolioPlanSummary;
@@ -68,22 +64,21 @@ export function TonightPlan({
           </Button>
         )}
       </div>
-      {needsConversationModel && state && onConnect && onDisconnect ? (
-        <ProviderConnections state={state} language={language} compact onConnect={onConnect} onDisconnect={onDisconnect} />
-      ) : needsConversationModel && onOpenSettings ? (
-        <Button variant="primary" className="mt-1" onClick={onOpenSettings}>{ko ? "대화 모델 연결" : "Connect a conversation model"}</Button>
+      <div className="grid gap-2">
+        {items.length > 0
+          ? items.map((item, index) => (
+              <TonightCard key={item.id} index={index} item={item} checked={checked[item.id] !== false} ko={ko} onToggle={() => setChecked((current) => ({ ...current, [item.id]: current[item.id] === false }))} />
+            ))
+          : [0, 1, 2].map((index) => <EmptyTonightCard key={index} index={index} ko={ko} />)}
+      </div>
+      {needsConversationModel && onOpenSettings ? (
+        <Button variant="primary" className="mt-3" onClick={onOpenSettings}>{ko ? "설정에서 모델 연결" : "Connect a model in Settings"}</Button>
       ) : needsOvernightWorker ? (
-        <div className="grid gap-2">
+        <div className="mt-3 grid gap-2">
           <p className="text-[12px] leading-5 text-ink-muted">{ko ? "Claude Code, Codex, Grok Build, Pi Agent 중 하나를 이 Mac의 PATH에 두고 공식 CLI로 로그인하세요." : "Put Claude Code, Codex, Grok Build, or Pi Agent on this Mac’s PATH and sign in with that official CLI."}</p>
           {onOpenSettings && <Button variant="secondary" className="w-fit" onClick={onOpenSettings}>{ko ? "Overnight CLI 명령 보기" : "Show Overnight CLI commands"}</Button>}
         </div>
-      ) : (
-        <div className="grid gap-2">
-          {items.map((item, index) => (
-            <TonightCard key={item.id} index={index} item={item} checked={checked[item.id] !== false} ko={ko} onToggle={() => setChecked((current) => ({ ...current, [item.id]: current[item.id] === false }))} />
-          ))}
-        </div>
-      )}
+      ) : null}
       {error && <p className="mt-3 text-[11px] text-danger" role="alert">{error}</p>}
     </section>
   );
@@ -102,7 +97,7 @@ function tonightHeading({
   needsConversationModel?: boolean;
   needsOvernightWorker?: boolean;
 }) {
-  if (needsConversationModel) return ko ? "대화 모델을 연결하면 오늘 밤 카드 3장이 여기 생깁니다" : "Connect a conversation model to see tonight’s 3 cards";
+  if (needsConversationModel && items.length === 0) return ko ? "오늘 밤 카드 3장" : "Tonight's 3 cards";
   if (needsOvernightWorker) return ko ? "Overnight CLI가 아직 PATH에 없습니다" : "An Overnight CLI is not on PATH yet";
   if (preparing && items.length === 0) return ko ? "Morrow가 오늘 밤 일을 고르는 중" : "Morrow is choosing tonight's work";
   if (items.length === 0) return ko ? "오늘 밤 준비된 Overnight가 없어요" : "No Overnight is ready tonight";
@@ -122,11 +117,22 @@ function tonightCopy({
   needsConversationModel?: boolean;
   needsOvernightWorker?: boolean;
 }) {
-  if (needsConversationModel) return ko ? "아래에서 하나를 연결하세요. 연결되면 Morrow가 카드 최대 3장을 고르고, 읽고 체크를 뺀 뒤 시작을 누르면 됩니다." : "Connect one below. Morrow then picks up to 3 cards. Read them, uncheck any, press Start.";
+  if (needsConversationModel && items.length === 0) return ko ? "모델은 설정에서 연결합니다. 연결되면 Morrow가 이 칸을 채웁니다." : "Connect a model in Settings. Morrow then fills these slots.";
   if (needsOvernightWorker) return ko ? "대화 모델과는 별개입니다. 공식 CLI에서 로그인하세요. 이 앱 안에서 Overnight 계정에 로그인하지 않습니다." : "This is separate from the conversation model. Sign in with the official CLI. This app does not log into Overnight accounts.";
   if (preparing && items.length === 0) return ko ? "파일은 바꾸지 않아요. 카드가 뜨면 읽고, 빼거나, 시작을 누르면 됩니다." : "No files are changing. When the cards appear, read them, uncheck any, press Start.";
   if (items.length === 0) return ko ? "0개도 정상이에요. 맡길 일이 있으면 이 대화에서 Morrow에게 말하면 됩니다." : "Zero is valid. Tell Morrow here if you want something left overnight.";
   return ko ? "체크된 일만 시작합니다. 빼거나 Morrow에게 다른 걸 부탁해도 됩니다." : "Only checked work starts. Uncheck any, or tell Morrow you want something else.";
+}
+
+function EmptyTonightCard({ index, ko }: { index: number; ko: boolean }) {
+  return (
+    <div className="flex gap-3 rounded-[12px] border border-line bg-surface-raised px-3.5 py-3">
+      <span className="min-w-0 flex-1">
+        <small className="font-mono text-[9px] tracking-[0.12em] text-ink-faint">{`OVERNIGHT ${index + 1}`}</small>
+        <strong className="mt-0.5 block text-[13px] leading-5">{ko ? "아직 비어 있음" : "Empty"}</strong>
+      </span>
+    </div>
+  );
 }
 
 function TonightCard({ item, index, checked, ko, onToggle }: {


### PR DESCRIPTION
홈에 제공자 6칸이 있었다. 이제 빈 카드 3장과 설정으로 가는 버튼만 있다. 연결은 설정에서 한다.

Ask Morrow 홈에서 ProviderConnections를 뺐다. 계획이 없으면 OVERNIGHT 1/2/3 빈 칸을 보여 준다. 버튼은 설정으로 보낸다. Settings의 모델 목록은 그대로다.

라이브 창은 이 세션에서 캡처하지 못했다. 창이 현재 화면에 없고 screencapture가 이미지를 만들지 못했다. 스크린샷은 PR에 넣지 않는다.