### PR TITLE
Morrow에게 말하면 오늘 밤 카드가 바뀐다

### DIFF
--- a/electron/runtime/morrow-overnight-intent.test.ts
+++ b/electron/runtime/morrow-overnight-intent.test.ts
@@ -8,6 +8,9 @@ describe("Overnight preparation intent", () => {
     "자리를 비운 동안 처리할 일을 추천해줘",
     "Plan bounded unattended work",
     "Plan repository work for tonight",
+    "the first overnight isn't important, deadline in 2 weeks, recommend something else.",
+    "이거 빼",
+    "첫 카드가 너무 멀어요. 다른 거 추천해줘",
   ])("recognizes a read-only preparation request: %s", (text) => {
     expect(isOvernightPreparationRequest(text)).toBe(true);
   });

--- a/electron/runtime/morrow-service.ts
+++ b/electron/runtime/morrow-service.ts
@@ -747,7 +747,7 @@ export class MorrowService {
       this.session.sessionManager.appendSessionInfo(sessionTitle(text));
     }
     this.preparingOvernight = isOvernightPreparationRequest(text);
-    this.preparingOvernightUserGoal = this.preparingOvernight ? text : undefined;
+    this.preparingOvernightUserGoal = text;
     try {
       await this.session.prompt(text, this.session.isStreaming ? { streamingBehavior: "followUp" } : undefined);
     } finally {
@@ -1108,6 +1108,11 @@ function portfolioAssessmentSummary(
   };
 }
 
+export function isTonightRevisionRequest(text: string) {
+  return /(?:이거\s*빼|다른\s*(?:거|것|일|세트|카드)|다른\s*걸|recommend\s+something\s+else|(?:the\s+)?wrong\s+job|too\s+far(?:\s+away)?|isn'?t\s+important|중요하지\s*않|너무\s*멀)/iu.test(text);
+}
+
 export function isOvernightPreparationRequest(text: string) {
-  return /(?:\bovernight\b|오버나이트|밤새|밤샘|무인\s*(?:실행|작업)|자리를\s*비운\s*동안|(?:오늘|금일)\s*밤[^.!?\n]{0,80}(?:맡|작업|실행|계획)|\bunattended\s+(?:work|run|execution)\b|\b(?:run|work|plan)\b[^.!?\n]{0,80}\btonight\b)/iu.test(text);
+  return /(?:\bovernight\b|오버나이트|밤새|밤샘|무인\s*(?:실행|작업)|자리를\s*비운\s*동안|(?:오늘|금일)\s*밤[^.!?\n]{0,80}(?:맡|작업|실행|계획)|\bunattended\s+(?:work|run|execution)\b|\b(?:run|work|plan)\b[^.!?\n]{0,80}\btonight\b)/iu.test(text)
+    || isTonightRevisionRequest(text);
 }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -7,6 +7,7 @@ import type {
   ConversationDetail,
   GitHubAuthState,
   MorrowBridge,
+  MorrowEvent,
   OvernightPortfolioPlanItemSummary,
   OvernightPortfolioPlanSummary,
   OvernightPortfolioRunSummary,
@@ -538,5 +539,104 @@ describe("GitHub identity gate", () => {
 
     finishGitHub({ status: "authenticated", profile: { id: 42, login: "synthetic-user" } });
     await waitFor(() => expect(bridge.bootstrap).toHaveBeenCalledOnce());
+  });
+});
+
+describe("Morrow revise tonight set", () => {
+  it("shows the newest draft after a revision turn and drops the old outcomes", async () => {
+    const oldItem = planItem("one", "Ship the login fix");
+    const newItem = planItem("new-1", "Replace the login work with a closer deadline");
+    const older = plan([oldItem], { id: "tonight-plan", createdAt: "2026-08-26T07:00:00.000Z" });
+    const newer = plan([newItem, planItem("new-2", "Ship the docs pass tonight")], {
+      id: "revised-plan",
+      createdAt: "2026-08-26T08:00:00.000Z",
+    });
+    const initial = state({
+      providers: [{ id: "test", name: "Test", connected: true, authTypes: ["api_key"] }],
+      models: [{ id: "model", provider: "test", name: "Test model", reasoning: false }],
+      conversations: [{ id: "conversation", path: "conversation", title: "Overnight planning", createdAt: "2026-08-26T07:00:00.000Z", updatedAt: "2026-08-26T07:00:00.000Z", messageCount: 0 }],
+      orchestration: orchestration({
+        providerRoutes: [{ provider: "codex", label: "Codex", status: "ready" }],
+        portfolioPlans: [older],
+      }),
+    });
+    const revisedConversation: ConversationDetail = {
+      ...emptyConversation,
+      messages: [
+        { id: "u1", role: "user", parts: [{ type: "text", text: "the first overnight isn't important, deadline in 2 weeks, recommend something else." }] },
+        { id: "a1", role: "assistant", parts: [{ type: "text", text: "I replaced tonight's set." }] },
+      ],
+      busy: false,
+    };
+    let emit: (event: MorrowEvent) => void = () => undefined;
+    const bootstrap = vi.fn(async () => initial);
+    const bridge = morrowBridge({
+      bootstrap,
+      openConversation: vi.fn(async () => emptyConversation),
+      onEvent: (listener) => {
+        emit = listener;
+        return () => undefined;
+      },
+    });
+    window.morrow = bridge;
+    const { default: App } = await import("./App");
+    render(<App />);
+
+    const tonight = await screen.findByLabelText("Tonight's overnights");
+    expect(tonight).toHaveTextContent("Ship the login fix");
+    expect(screen.getByRole("button", { name: "Start 1 selected" })).toBeInTheDocument();
+
+    bootstrap.mockResolvedValue({
+      ...initial,
+      orchestration: orchestration({
+        providerRoutes: [{ provider: "codex", label: "Codex", status: "ready" }],
+        portfolioPlans: [older, newer],
+      }),
+    });
+    await act(async () => {
+      emit({ type: "conversation", sessionId: revisedConversation.id, conversation: revisedConversation });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(bootstrap.mock.calls.length).toBeGreaterThan(1));
+    expect(tonight).toHaveTextContent("Replace the login work with a closer deadline");
+    expect(tonight).toHaveTextContent("Ship the docs pass tonight");
+    expect(tonight).not.toHaveTextContent("Ship the login fix");
+    expect(screen.getByRole("button", { name: "Start 2 selected" })).toBeInTheDocument();
+    expect(bridge.startOvernightPortfolio).not.toHaveBeenCalled();
+  });
+
+  it("never starts Overnight from chat text such as 돌리기", async () => {
+    const item = planItem("one", "Ship the login fix");
+    const initial = state({
+      providers: [{ id: "test", name: "Test", connected: true, authTypes: ["api_key"] }],
+      models: [{ id: "model", provider: "test", name: "Test model", reasoning: false }],
+      conversations: [{ id: "conversation", path: "conversation", title: "Overnight planning", createdAt: "2026-08-26T07:00:00.000Z", updatedAt: "2026-08-26T07:00:00.000Z", messageCount: 0 }],
+      orchestration: orchestration({
+        providerRoutes: [{ provider: "codex", label: "Codex", status: "ready" }],
+        portfolioPlans: [plan([item])],
+      }),
+    });
+    const sendMessage = vi.fn(async () => undefined);
+    const bridge = morrowBridge({
+      bootstrap: vi.fn(async () => initial),
+      openConversation: vi.fn(async () => emptyConversation),
+      sendMessage,
+    });
+    window.morrow = bridge;
+    const { default: App } = await import("./App");
+    render(<App />);
+
+    expect(await screen.findByRole("button", { name: "Start 1 selected" })).toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText("Talk to Morrow about anything…"), { target: { value: "돌리기" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    await waitFor(() => expect(sendMessage).toHaveBeenCalledWith({ text: "돌리기" }));
+
+    fireEvent.change(screen.getByPlaceholderText("Talk to Morrow about anything…"), { target: { value: "start overnight" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    await waitFor(() => expect(sendMessage).toHaveBeenCalledWith({ text: "start overnight" }));
+    expect(bridge.startOvernightPortfolio).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Start 1 selected" })).toBeInTheDocument();
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { OvernightView } from "./components/OvernightView";
 import { OvernightPulse } from "./components/OvernightPulse";
 import { getMorrowBridge } from "./lib/bridge";
 import { transitionState, updateStateWithoutTransition } from "./lib/motion";
+import { visibleTonightPlan } from "./lib/tonight";
 import type {
   AppLanguage,
   AppView,
@@ -383,7 +384,7 @@ function App() {
           updateStateWithoutTransition(() => setState((current) => current ? { ...current, thinkingLevel: level } : current));
         }}
         onOpenSettings={() => changeView("settings")}
-        tonightPlan={state.orchestration.portfolioPlans.find((plan) => plan.status === "draft" && Date.now() < Date.parse(plan.expiresAt) && !state.orchestration.portfolioRuns.some((run) => run.planId === plan.id))}
+        tonightPlan={visibleTonightPlan(state.orchestration.portfolioPlans, state.orchestration.portfolioRuns)}
         tonightPreparing={overnightPreparing}
         hasReadyOvernightWorker={hasReadyOvernightWorker}
         onStartTonight={startOvernightPortfolio}

--- a/src/components/OvernightView.tsx
+++ b/src/components/OvernightView.tsx
@@ -10,7 +10,7 @@ import type {
 } from "../shared/contracts";
 import { overnightCliLoginCommand } from "../lib/overnight-cli";
 import { overnightTickets } from "../lib/overnight-tickets";
-import { startedRunItems, tonightPlanItems } from "../lib/tonight";
+import { startedRunItems, tonightPlanItems, visibleTonightPlan } from "../lib/tonight";
 import { CopyCommandButton } from "./CopyCommandButton";
 import { OvernightCalendarButton, OvernightDateEmptyState, overnightDateKey } from "./OvernightCalendar";
 import { OvernightKanban } from "./OvernightKanban";
@@ -45,10 +45,10 @@ export function OvernightView(props: OvernightViewProps) {
     .filter((run) => overnightDateKey(run.startedAt, props.snapshot.context.timeZone) === selectedDate)
     .sort((left, right) => Number(activeRunStatuses.has(right.status)) - Number(activeRunStatuses.has(left.status)) || right.startedAt.localeCompare(left.startedAt)), [props.snapshot.context.timeZone, runs, selectedDate]);
   const selectedActiveRun = selectedRuns.find((run) => activeRunStatuses.has(run.status));
-  const livePlan = plans.find((plan) => plan.status === "draft"
-    && !runs.some((run) => run.planId === plan.id)
-    && Date.now() < Date.parse(plan.expiresAt)
-    && overnightDateKey(plan.createdAt, props.snapshot.context.timeZone) === selectedDate);
+  const livePlan = visibleTonightPlan(
+    plans.filter((plan) => overnightDateKey(plan.createdAt, props.snapshot.context.timeZone) === selectedDate),
+    runs,
+  );
   const runCards = selectedRuns.flatMap((run) => {
     const plan = plans.find((candidate) => candidate.id === run.planId);
     return startedRunItems(run.items).map((item) => ({ run, item, planItem: plan?.items.find((candidate) => candidate.id === item.itemId) }));

--- a/src/lib/tonight.test.ts
+++ b/src/lib/tonight.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { OvernightPortfolioPlanSummary, OvernightPortfolioRunItemSummary } from "../shared/contracts";
-import { startedRunItems, tonightPlanItems } from "./tonight";
+import { startedRunItems, tonightPlanItems, visibleTonightPlan } from "./tonight";
 
 function plan(): OvernightPortfolioPlanSummary {
   const item = (id: string, outcome: string): OvernightPortfolioPlanSummary["items"][number] => ({
@@ -59,5 +59,35 @@ describe("tonight visibility", () => {
       { itemId: "four", provider: "pi", providerLabel: "Pi Agent", status: "skipped" },
     ];
     expect(startedRunItems(items).map((item) => item.itemId)).toEqual(["two", "three"]);
+  });
+
+  it("picks the newest live draft even when an older draft is listed first", () => {
+    const older = plan();
+    const newer: OvernightPortfolioPlanSummary = {
+      ...plan(),
+      id: "revised-plan",
+      createdAt: "2026-08-27T01:00:00.000Z",
+      items: plan().items.slice(0, 2).map((item, index) => ({
+        ...item,
+        id: index === 0 ? "new-1" : "new-2",
+        stableKey: index === 0 ? "new-1" : "new-2",
+        outcome: index === 0 ? "Replace the login work with a closer deadline" : "Ship the docs pass tonight",
+        title: index === 0 ? "Replace the login work with a closer deadline" : "Ship the docs pass tonight",
+      })),
+    };
+    const visible = visibleTonightPlan([older, newer], []);
+    expect(visible?.id).toBe("revised-plan");
+    expect(tonightPlanItems(visible).map((item) => item.outcome)).toEqual([
+      "Replace the login work with a closer deadline",
+      "Ship the docs pass tonight",
+    ]);
+    expect(tonightPlanItems(visible).some((item) => item.outcome === "Ship the login fix")).toBe(false);
+  });
+
+  it("ignores expired and already-started drafts when choosing tonight", () => {
+    const expired = { ...plan(), id: "expired", expiresAt: "2026-08-27T00:00:00.000Z", createdAt: "2026-08-27T02:00:00.000Z" };
+    const started = { ...plan(), id: "started-plan", createdAt: "2026-08-27T03:00:00.000Z" };
+    const live = { ...plan(), id: "live-plan", createdAt: "2026-08-27T01:00:00.000Z" };
+    expect(visibleTonightPlan([expired, started, live], [{ planId: "started-plan" }], Date.parse("2026-08-27T04:00:00.000Z"))?.id).toBe("live-plan");
   });
 });

--- a/src/lib/tonight.ts
+++ b/src/lib/tonight.ts
@@ -1,6 +1,7 @@
 import type {
   OvernightPortfolioPlanSummary,
   OvernightPortfolioRunItemSummary,
+  OvernightPortfolioRunSummary,
 } from "../shared/contracts";
 
 export const TONIGHT_CARD_LIMIT = 3;
@@ -11,4 +12,22 @@ export function tonightPlanItems(plan?: OvernightPortfolioPlanSummary) {
 
 export function startedRunItems(items: readonly OvernightPortfolioRunItemSummary[] = []) {
   return items.filter((item) => item.status !== "skipped");
+}
+
+export function visibleTonightPlan(
+  plans: readonly OvernightPortfolioPlanSummary[] = [],
+  runs: readonly Pick<OvernightPortfolioRunSummary, "planId">[] = [],
+  now = Date.now(),
+): OvernightPortfolioPlanSummary | undefined {
+  const started = new Set(runs.map((run) => run.planId));
+  return plans.reduce<OvernightPortfolioPlanSummary | undefined>((newest, plan) => {
+    if (plan.status !== "draft") return newest;
+    if (!Number.isFinite(Date.parse(plan.expiresAt)) || now >= Date.parse(plan.expiresAt)) return newest;
+    if (started.has(plan.id)) return newest;
+    if (!newest) return plan;
+    const created = plan.createdAt.localeCompare(newest.createdAt);
+    if (created > 0) return plan;
+    if (created === 0 && plan.id.localeCompare(newest.id) > 0) return plan;
+    return newest;
+  }, undefined);
 }


### PR DESCRIPTION
카드가 틀리다고 말하면 새 세트만 남는다. 대화는 Overnight를 시작하지 않는다.

오늘 밤 카드는 가장 최근 draft만 보여 준다. 예전 draft가 목록에 남아도 새 결과가 앞에 온다.

Morrow가 `prepare_overnight`를 부르면 현재 Night Plan을 교체한다. `이거 빼`처럼 카드를 고치라는 말도 준비 요청으로 본다. 지금 보낸 문장을 그대로 목표로 넘긴다.

Start는 새 카드의 체크에만 있다. `돌리기`나 `start overnight`는 대화를 보낼 뿐 실행하지 않는다.

## 확인
- 최신 draft가 이긴다.
- 예전 결과는 화면에서 사라진다.
- 대화 후에도 Start는 새 체크에만 남는다.