### PR TITLE
Overnight는 오늘 목록이다

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -404,7 +404,6 @@ function App() {
         }}
         onOpenSettings={() => changeView("settings")}
         onOpenChat={() => changeView("chat")}
-        onStartPortfolio={startOvernightPortfolio}
         onStopPortfolio={async (runId) => {
           setOvernightError(undefined);
           try { await stopOvernightPortfolio(runId); }

--- a/src/components/OvernightView.test.tsx
+++ b/src/components/OvernightView.test.tsx
@@ -103,7 +103,6 @@ function props(overrides: Partial<React.ComponentProps<typeof OvernightView>> = 
     preparing: false,
     onPrepare: vi.fn(async () => undefined),
     onOpenSettings: vi.fn(),
-    onStartPortfolio: vi.fn(async () => undefined),
     onStopPortfolio: vi.fn(async () => undefined),
     ...overrides,
   };
@@ -247,8 +246,7 @@ describe("Overnight one-button workspace", () => {
 
   it("keeps a failed start simple and retryable without exposing runtime errors", async () => {
     const item = planItem("first", "Retryable outcome", "codex");
-    const start = vi.fn(async () => { throw new Error("Error invoking remote method: private runtime detail"); });
-    render(<OvernightView {...props({ snapshot: snapshot({ portfolioPlans: [plan([item])] }), onStartPortfolio: start })} />);
+    render(<OvernightView {...props({ snapshot: snapshot({ portfolioPlans: [plan([item])] }) })} />);
 
     expect(screen.getByText("Retryable outcome")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Start Overnight" })).not.toBeInTheDocument();
@@ -358,8 +356,12 @@ describe("Overnight one-button workspace", () => {
     const item = planItem("first", "Blocked until checked", "codex");
     render(<OvernightView {...props({ snapshot: snapshot({ portfolioPlans: [plan([item])] }) })} />);
 
+    expect(screen.getByRole("heading", { name: "Overnight", level: 1 })).toBeInTheDocument();
     expect(screen.getByText("Blocked until checked")).toBeInTheDocument();
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Start Overnight" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Start \d+ selected/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("region", { name: /Status for/ })).not.toBeInTheDocument();
   });
 
   it("keeps stale cards visible and lets the launch boundary revalidate them when refresh fails", () => {
@@ -385,5 +387,33 @@ describe("Overnight one-button workspace", () => {
     expect(screen.getByRole("region", { name: "Overnights" })).toBe(list);
     expect(screen.getByText("Short-lived purpose")).toBeInTheDocument();
     expect(prepare).not.toHaveBeenCalled();
+  });
+
+  it("does not fill an empty night with vacant overnight slots", () => {
+    render(<OvernightView {...props()} />);
+
+    expect(screen.getByRole("heading", { name: "Overnight", level: 1 })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "No Overnight is ready tonight" })).toBeInTheDocument();
+    expect(screen.queryByText("Empty")).not.toBeInTheDocument();
+    expect(screen.queryByText("OVERNIGHT 1")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Start \d+ selected/ })).not.toBeInTheDocument();
+  });
+
+  it("opens one kanban from the list and returns to Overnight", () => {
+    const first = planItem("first", "First outcome", "claude");
+    const second = planItem("second", "Second outcome", "grok");
+    render(<OvernightView {...props({ snapshot: snapshot({ portfolioPlans: [plan([first, second])] }) })} />);
+
+    expect(screen.getByRole("heading", { name: "Overnight", level: 1 })).toBeInTheDocument();
+    expect(screen.queryByRole("region", { name: /Status for/ })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /First outcome/ }));
+    expect(screen.getByRole("region", { name: /Status for First outcome/ })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Second outcome/ })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "All overnights" }));
+    expect(screen.getByRole("heading", { name: "Overnight", level: 1 })).toBeInTheDocument();
+    expect(screen.queryByRole("region", { name: /Status for/ })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Second outcome/ })).toBeInTheDocument();
   });
 });

--- a/src/components/OvernightView.tsx
+++ b/src/components/OvernightView.tsx
@@ -15,7 +15,6 @@ import { CopyCommandButton } from "./CopyCommandButton";
 import { OvernightCalendarButton, OvernightDateEmptyState, overnightDateKey } from "./OvernightCalendar";
 import { OvernightKanban } from "./OvernightKanban";
 import { Button } from "./ui/Button";
-import { Surface } from "./ui/Surface";
 
 interface OvernightViewProps {
   hidden?: boolean;
@@ -27,7 +26,6 @@ interface OvernightViewProps {
   onPrepare(): Promise<void>;
   onOpenSettings(): void;
   onOpenChat?(): void;
-  onStartPortfolio?(planId: string, itemIds?: string[]): Promise<void>;
   onStopPortfolio(runId: string): Promise<void>;
 }
 
@@ -76,8 +74,7 @@ export function OvernightView(props: OvernightViewProps) {
     <main className="overnight-view h-dvh overflow-y-auto bg-night px-[clamp(32px,5vw,80px)] pb-16 pt-[clamp(58px,7vh,82px)] text-ink max-[1120px]:px-9" hidden={props.hidden}>
       <header className="overnight-head mx-auto grid w-full max-w-[1080px] grid-cols-[minmax(0,1fr)_auto] items-end gap-8 border-b border-line pb-7">
         <div>
-          <span className="eyebrow font-mono text-[10px] font-semibold tracking-[0.16em] text-amber">MORROW · OVERNIGHT</span>
-          <h1 className="mt-3 text-[clamp(40px,4.6vw,58px)] font-medium leading-[0.96] tracking-[-0.055em]">
+          <h1 className="text-[clamp(32px,3.6vw,48px)] font-medium leading-[0.96] tracking-[-0.05em]">
             {selectedCard ? (selectedCard.planItem?.outcome ?? selectedCard.runItem?.outcome ?? "Overnight") : "Overnight"}
           </h1>
           <p className="mt-3 max-w-[680px] text-sm leading-6 text-ink-muted">
@@ -93,20 +90,20 @@ export function OvernightView(props: OvernightViewProps) {
         )}
       </header>
 
-      <Surface className="overnight-section overnight-primary-state portfolio-primary !overflow-visible" aria-label={ko ? "Overnights" : "Overnights"}>
+      <section className="overnight-list mx-auto mt-8 w-full max-w-[1080px]" aria-label={ko ? "Overnights" : "Overnights"}>
         {selectedActiveRun && !selectedCard && <ActiveRunBar run={selectedActiveRun} ko={ko} onStop={props.onStopPortfolio} />}
 
         {props.error && <div className="overnight-error flex items-center justify-between gap-3" role="alert"><span>{props.error}</span><button type="button" className="shrink-0 font-semibold underline underline-offset-2" onClick={() => void props.onPrepare()}>{ko ? "다시 시도" : "Try again"}</button></div>}
 
         {selectedCard ? (
           <OvernightCard index={selectedCard.index} planItem={selectedCard.planItem} runItem={selectedCard.runItem} ko={ko} />
-        ) : (
-          <div className="grid gap-3" aria-label={ko ? "선택한 날짜의 Overnight" : "Overnights for selected date"}>
+        ) : cards.length > 0 ? (
+          <ul className="grid gap-2" aria-label={ko ? "선택한 날짜의 Overnight" : "Overnights for selected date"}>
             {cards.map((card) => (
-              <button
+              <li key={card.key}>
+                <button
                 type="button"
-                key={card.key}
-                className="flex w-full items-center justify-between gap-4 rounded-[12px] border border-line bg-surface/50 px-4 py-3.5 text-left transition-[background-color,border-color] duration-150 ease-morrow hover:border-white/15 hover:bg-surface-raised"
+                className="flex w-full items-center justify-between gap-4 rounded-[12px] border border-line bg-transparent px-4 py-3.5 text-left transition-[background-color,border-color] duration-150 ease-morrow hover:border-white/15 hover:bg-surface"
                 onClick={() => setSelectedKey(card.key)}
               >
                 <span className="min-w-0">
@@ -116,11 +113,10 @@ export function OvernightView(props: OvernightViewProps) {
                 </span>
                 <ChevronRight size={16} className="shrink-0 text-ink-faint" />
               </button>
+              </li>
             ))}
-          </div>
-        )}
-
-        {cards.length === 0 && !selectedCard && (
+          </ul>
+        ) : (
           <EmptyToday
             date={selectedDate}
             today={today}
@@ -132,7 +128,7 @@ export function OvernightView(props: OvernightViewProps) {
             onOpenChat={props.onOpenChat}
           />
         )}
-      </Surface>
+      </section>
     </main>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -2725,7 +2725,7 @@ button:active:not(:disabled) {
 
 .overnight-calendar[open] > summary > svg:last-child { transform: rotate(90deg); }
 
-.overnight-calendar__popover { position: absolute; top: calc(100% + 8px); right: 0; width: 322px; padding: 12px; color: var(--ink-primary); border: 1px solid var(--etched-edge); border-radius: 13px; background: rgba(16, 20, 27, .985); box-shadow: 0 28px 75px rgba(0, 0, 0, .5); backdrop-filter: blur(20px); }
+.overnight-calendar__popover { position: absolute; top: calc(100% + 8px); right: 0; width: 322px; padding: 12px; color: var(--ink-primary); border: 1px solid var(--etched-edge); border-radius: 13px; background: rgba(16, 20, 27, .985); box-shadow: 0 28px 75px rgba(0, 0, 0, .5); }
 
 .overnight-calendar__popover > header { height: 34px; display: grid; grid-template-columns: 32px 1fr 32px; align-items: center; }
 


### PR DESCRIPTION
Overnight 탭은 오늘 시작한 일을 목록으로 보여 준다. Start는 Ask Morrow에만 있다. 카드 없으면 오늘 밤 준비된 일이 없다고 말한다.

유리 Surface와 시작 버튼을 뺐다. 빈 칸 3장을 채우지 않는다. 카드를 열면 그 Overnight의 Kanban만 보인다.