### PR TITLE
설정은 Overnight CLI 넷만 보여 준다

### DIFF
--- a/src/components/SettingsView.test.tsx
+++ b/src/components/SettingsView.test.tsx
@@ -141,19 +141,21 @@ describe("Settings user-facing safety contract", () => {
     expect(document.body).not.toHaveTextContent(/local first|local by default|Pi SDK|Pi runtime/i);
   });
 
-  it("keeps setup for exactly the four Overnight workers out of the Overnight page", async () => {
+  it("always lists the four official Overnight CLIs from PATH, not a canary", () => {
     const verify = vi.fn(async () => undefined);
     render(
       <SettingsView
         state={{
           ...state,
+          providers: [{ id: "anthropic", name: "Anthropic", connected: false, authTypes: ["oauth"] }],
           orchestration: {
             ...state.orchestration,
             providerRoutes: [
-              { provider: "claude", label: "Claude Code", status: "blocked", verification: { state: "unsupported", canVerify: false } },
+              { provider: "claude", label: "Claude Code", status: "blocked", reason: "containment unavailable", verification: { state: "unsupported", canVerify: true } },
               { provider: "codex", label: "Codex", status: "setup_required", verification: { state: "not_verified", canVerify: true } },
-              { provider: "grok", label: "Grok Build", status: "blocked", verification: { state: "unsupported", canVerify: false } },
-              { provider: "pi", label: "Pi Agent", status: "blocked", verification: { state: "unsupported", canVerify: false } },
+              { provider: "cursor" as "claude", label: "Cursor", status: "ready" },
+              { provider: "hermes" as "claude", label: "Hermes", status: "ready" },
+              { provider: "openclaw" as "claude", label: "OpenClaw", status: "ready" },
             ],
           },
         }}
@@ -167,14 +169,27 @@ describe("Settings user-facing safety contract", () => {
       />,
     );
 
-    for (const provider of ["Claude Code", "Codex", "Grok Build", "Pi Agent"]) {
-      expect(screen.getByText(provider)).toBeInTheDocument();
-    }
-    expect(document.body).not.toHaveTextContent(/Cursor|Hermes|OpenClaw/);
-    expect(screen.getAllByText(/Not installed/)).toHaveLength(4);
-    expect(screen.getByText("codex login")).toBeInTheDocument();
+    const overnight = screen.getByRole("heading", { name: "Overnight CLIs" }).closest(".settings-section");
+    expect(overnight).toHaveTextContent("Claude Code");
+    expect(overnight).toHaveTextContent("Codex");
+    expect(overnight).toHaveTextContent("Grok Build");
+    expect(overnight).toHaveTextContent("Pi Agent");
+    expect(overnight).not.toHaveTextContent(/Cursor|Hermes|OpenClaw/);
+    expect(overnight).toHaveTextContent("Installed means the command is on PATH");
+    expect(overnight).toHaveTextContent("Installed · ready for Overnight");
+    expect(overnight).toHaveTextContent("Not installed · not on PATH");
+    expect(overnight).toHaveTextContent("claude auth login");
+    expect(overnight).toHaveTextContent("codex login");
+    expect(overnight).toHaveTextContent("grok");
+    expect(overnight).toHaveTextContent("bundled with Morrow");
+    expect(screen.getByRole("button", { name: "Copy claude auth login" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Copy codex login" })).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Safety check" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Copy grok" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Copy .*Pi|bundled/i })).not.toBeInTheDocument();
+    expect(overnight).not.toHaveTextContent(/Safety check|OS containment|canary/i);
+    expect(overnight?.querySelectorAll("button")).toHaveLength(3);
+    expect(screen.queryByRole("button", { name: /Connect/ })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Sign in with your Anthropic/ })).toBeInTheDocument();
     expect(verify).not.toHaveBeenCalled();
   });
 

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -1,5 +1,5 @@
 import { ExternalLink, FolderLock, Github, LogOut, Send, ShieldCheck } from "lucide-react";
-import { overnightCliLoginCommand } from "../lib/overnight-cli";
+import { officialOvernightCliCards } from "../lib/overnight-cli";
 import type { AppLanguage, BootstrapState, GitHubProfile, OvernightExecutionProvider } from "../shared/contracts";
 import { CopyCommandButton } from "./CopyCommandButton";
 import { ProviderConnections } from "./ProviderConnections";
@@ -61,12 +61,11 @@ export function SettingsView({ state, error, githubProfile, githubOffline, onCon
 
         <Surface className="settings-section mt-0 rounded-t-none border-t-0 p-5 shadow-none">
           <div className="settings-section__intro"><h2 className="flex items-center gap-2 text-base font-semibold"><ShieldCheck size={18} />{ko ? "Overnight CLI" : "Overnight CLIs"}</h2><p className="mt-1.5 text-[13px] leading-5 text-ink-muted">{ko ? "설치됨은 PATH에서 명령을 찾았다는 뜻입니다. 로그인 명령을 복사해 Terminal에서 실행하세요. 이 앱 안에서 Overnight 계정에 로그인하지 않습니다." : "Installed means the command is on PATH. Copy a login command and run it in Terminal. This app does not log into Overnight accounts."}</p></div>
-          <div className="mt-4 grid gap-2">{state.orchestration.providerRoutes.map((route) => {
-            const command = overnightCliLoginCommand(route.provider);
+          <div className="mt-4 grid gap-2">{officialOvernightCliCards(state.orchestration.providerRoutes).map((cli) => {
             return (
-              <div key={route.provider} className="flex min-h-12 items-center justify-between gap-4 rounded-[12px] border border-line bg-surface/50 px-4 py-2.5">
-                <span className="min-w-0"><strong className="block text-sm">{route.label}</strong><small className="block truncate text-[11px] text-ink-faint">{route.status === "ready" ? (ko ? "설치됨 · Overnight에 사용 가능" : "Installed · ready for Overnight") : (ko ? "설치되지 않음 · PATH에 없음" : "Not installed · not on PATH")}</small><small className="mt-1 block font-mono text-[10px] text-ink-faint">{command ?? (ko ? "Morrow에 포함됨" : "bundled with Morrow")}</small></span>
-                {command && <CopyCommandButton command={command} language={state.language} />}
+              <div key={cli.provider} className="flex min-h-12 items-center justify-between gap-4 rounded-[12px] border border-line bg-surface/50 px-4 py-2.5">
+                <span className="min-w-0"><strong className="block text-sm">{cli.label}</strong><small className="block truncate text-[11px] text-ink-faint">{cli.installed ? (ko ? "설치됨 · Overnight에 사용 가능" : "Installed · ready for Overnight") : (ko ? "설치되지 않음 · PATH에 없음" : "Not installed · not on PATH")}</small><small className="mt-1 block font-mono text-[10px] text-ink-faint">{cli.loginCommand ?? (ko ? "Morrow에 포함됨" : "bundled with Morrow")}</small></span>
+                {cli.loginCommand && <CopyCommandButton command={cli.loginCommand} language={state.language} />}
               </div>
             );
           })}</div>

--- a/src/lib/overnight-cli.test.ts
+++ b/src/lib/overnight-cli.test.ts
@@ -10,9 +10,9 @@ import {
 function route(
   provider: OvernightProviderRouteSummary["provider"],
   status: OvernightProviderRouteSummary["status"],
-  label = provider,
+  label?: string,
 ): OvernightProviderRouteSummary {
-  return { provider, label, status };
+  return { provider, label: label ?? provider, status };
 }
 
 describe("official Overnight CLIs", () => {

--- a/src/lib/overnight-cli.test.ts
+++ b/src/lib/overnight-cli.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import type { OvernightProviderRouteSummary } from "../shared/contracts";
+import {
+  OFFICIAL_OVERNIGHT_CLIS,
+  officialOvernightCliCards,
+  overnightCliInstalledOnPath,
+  overnightCliLoginCommand,
+} from "./overnight-cli";
+
+function route(
+  provider: OvernightProviderRouteSummary["provider"],
+  status: OvernightProviderRouteSummary["status"],
+  label = provider,
+): OvernightProviderRouteSummary {
+  return { provider, label, status };
+}
+
+describe("official Overnight CLIs", () => {
+  it("names exactly the four official workers", () => {
+    expect(OFFICIAL_OVERNIGHT_CLIS.map((cli) => [cli.provider, cli.label])).toEqual([
+      ["claude", "Claude Code"],
+      ["codex", "Codex"],
+      ["grok", "Grok Build"],
+      ["pi", "Pi Agent"],
+    ]);
+  });
+
+  it("returns the official login command, and none for bundled Pi", () => {
+    expect(overnightCliLoginCommand("claude")).toBe("claude auth login");
+    expect(overnightCliLoginCommand("codex")).toBe("codex login");
+    expect(overnightCliLoginCommand("grok")).toBe("grok");
+    expect(overnightCliLoginCommand("pi")).toBeUndefined();
+  });
+
+  it("treats PATH presence, not a canary, as installed", () => {
+    expect(overnightCliInstalledOnPath("claude", route("claude", "ready"))).toBe(true);
+    expect(overnightCliInstalledOnPath("claude", route("claude", "blocked"))).toBe(true);
+    expect(overnightCliInstalledOnPath("codex", route("codex", "setup_required"))).toBe(false);
+    expect(overnightCliInstalledOnPath("grok")).toBe(false);
+    expect(overnightCliInstalledOnPath("pi")).toBe(true);
+    expect(overnightCliInstalledOnPath("pi", route("pi", "blocked"))).toBe(true);
+  });
+
+  it("always returns the four official cards and ignores evidence-only names", () => {
+    const cards = officialOvernightCliCards([
+      route("codex", "setup_required", "Codex"),
+      route("claude", "blocked", "Claude Code"),
+      { provider: "cursor" as OvernightProviderRouteSummary["provider"], label: "Cursor", status: "ready" },
+      { provider: "hermes" as OvernightProviderRouteSummary["provider"], label: "Hermes", status: "ready" },
+      { provider: "openclaw" as OvernightProviderRouteSummary["provider"], label: "OpenClaw", status: "ready" },
+    ]);
+
+    expect(cards.map((card) => card.label)).toEqual(["Claude Code", "Codex", "Grok Build", "Pi Agent"]);
+    expect(cards.map((card) => card.installed)).toEqual([true, false, false, true]);
+    expect(cards.map((card) => card.loginCommand)).toEqual([
+      "claude auth login",
+      "codex login",
+      "grok",
+      undefined,
+    ]);
+  });
+});

--- a/src/lib/overnight-cli.ts
+++ b/src/lib/overnight-cli.ts
@@ -1,8 +1,34 @@
-import type { OvernightExecutionProvider } from "../shared/contracts";
+import type { OvernightExecutionProvider, OvernightProviderRouteSummary } from "../shared/contracts";
+
+export const OFFICIAL_OVERNIGHT_CLIS = [
+  { provider: "claude", label: "Claude Code" },
+  { provider: "codex", label: "Codex" },
+  { provider: "grok", label: "Grok Build" },
+  { provider: "pi", label: "Pi Agent" },
+] as const;
 
 export function overnightCliLoginCommand(provider: OvernightExecutionProvider) {
   if (provider === "claude") return "claude auth login";
   if (provider === "codex") return "codex login";
   if (provider === "grok") return "grok";
   return undefined;
+}
+
+/** PATH/bundled presence only. A canary-blocked route is still installed. */
+export function overnightCliInstalledOnPath(
+  provider: OvernightExecutionProvider,
+  route?: Pick<OvernightProviderRouteSummary, "status">,
+) {
+  if (provider === "pi") return true;
+  return route?.status === "ready" || route?.status === "blocked";
+}
+
+export function officialOvernightCliCards(routes: readonly OvernightProviderRouteSummary[]) {
+  const byProvider = new Map(routes.map((route) => [route.provider, route]));
+  return OFFICIAL_OVERNIGHT_CLIS.map((cli) => ({
+    provider: cli.provider,
+    label: cli.label,
+    installed: overnightCliInstalledOnPath(cli.provider, byProvider.get(cli.provider)),
+    loginCommand: overnightCliLoginCommand(cli.provider),
+  }));
 }


### PR DESCRIPTION
설정은 Claude Code, Codex, Grok Build, Pi Agent만 보여 준다. 설치 여부는 PATH로 본다. 로그인은 각 공식 CLI에서 한다. 이 화면에 Connect는 없다.

## Summary
- Settings always lists the four official Overnight CLIs, even if extra routes leak in.
- Installed / Not installed comes from PATH (or bundled Pi), not a canary-blocked status.
- Each card shows the official login command and Copy command. Conversation-model Sign in stays.

## Test plan
- [x] `npx vitest run src/lib/overnight-cli.test.ts src/components/SettingsView.test.tsx src/App.test.tsx`
- [ ] Settings → Overnight CLIs shows only Claude Code, Codex, Grok Build, Pi Agent
- [ ] A CLI on PATH but canary-blocked still says Installed
- [ ] No Safety check, OS containment, canary, or Connect on those cards