### PR TITLE
feat(overnight): store one purpose card in SQLite

### DIFF
--- a/docs/adr/0055-overnight-sqlite-row.md
+++ b/docs/adr/0055-overnight-sqlite-row.md
@@ -1,0 +1,38 @@
+# ADR 0055: One Overnight purpose card is one SQLite row
+
+- Status: accepted
+- Written: 2026-08-28
+- Contract baseline: 2026-08-28
+- Relates to: [ADR 0002: Keep Context Briefs ephemeral and bounded](0002-context-briefs-are-ephemeral.md), [ADR 0054: Overnight launches through four execution routes](0054-four-overnight-execution-routes.md)
+
+## Context
+
+Overnight now treats a date as a workspace that can hold several purpose cards.
+Those cards need durable local storage before generators, boards, or Start wiring
+exist. Folding them into the JSON portfolio ledger would mix candidate identity
+with approval and run authority. Inventing a second Overnight domain object for
+the same purpose card would also split one product idea across two shapes.
+
+## Decision
+
+Store each purpose card as one row in `{dataDir}/overnight/overnights.sqlite`.
+
+The row status is exactly one of `candidate`, `deleted`, `cancelled`,
+`running`, or `ran`. Card fields stored now are `goal`, `finish_condition`,
+`work_ai`, `verify_ai` (defaulting to `work_ai`), `stall_hours`, and
+`decisions_log`. Column behavior beyond persistence comes later.
+
+`OvernightStore` opens that database when `MorrowService` constructs. A second
+table, `overnight_generation`, records the latest generation timestamp per local
+date and holds no transcript or excerpt columns.
+
+`OvernightPortfolioLedger` JSON remains the approval and run authority. Daily
+context briefs stay ephemeral under ADR 0002. `work_ai` and `verify_ai` stay
+inside the four `OvernightExecutionProvider` routes from ADR 0054.
+
+## Consequences
+
+- Purpose cards can survive process restart without touching approval files.
+- Illegal status values fail at the store boundary and cannot land as rows.
+- Kanban cards, 9pm generation, IPC, and Start remain separate follow-up work.
+- Replacing the portfolio ledger with this database is out of scope.

--- a/electron/runtime/morrow-service.ts
+++ b/electron/runtime/morrow-service.ts
@@ -54,6 +54,7 @@ import {
   OvernightPortfolioLedger,
   type OvernightPortfolioAssessmentRecord,
 } from "./overnight-portfolio-ledger";
+import { OvernightStore } from "./overnight-store";
 import {
   OvernightPortfolioService,
   type OvernightPortfolioContainmentControl,
@@ -318,6 +319,7 @@ export class MorrowService {
   private readonly sendEvent: SendEvent;
   private readonly configureRuntime?: (runtime: ModelRuntime) => Promise<void> | void;
   private readonly contextHome?: string;
+  private readonly overnightStore: OvernightStore;
   private readonly overnightPortfolio: MorrowPortfolioService;
   private readonly overnightPortfolioReadiness: OvernightPortfolioReadiness;
   private readonly overnightProviderVerification?: OvernightProviderVerificationPort;
@@ -359,6 +361,7 @@ export class MorrowService {
     this.dailyContextBuilder = options.dailyContextBuilder ?? collectDailyContextForEvaluation;
     this.overnightContextEvaluator = options.overnightContextEvaluator ?? evaluateOvernightContext;
     this.overnightContextModelPort = options.overnightContextModelPort;
+    this.overnightStore = new OvernightStore({ dataDir: options.dataDir });
     const portfolioLedger = new OvernightPortfolioLedger({ dataDir: options.dataDir });
     const providerControlPlane = options.overnightProviderControlPlane?.create({
       approvalClaims: {

--- a/electron/runtime/overnight-store.test.ts
+++ b/electron/runtime/overnight-store.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { OvernightStore } from "./overnight-store";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
+});
+
+describe("OvernightStore", () => {
+  it("insert then get returns the same fields", async () => {
+    const dataDir = await tempDataDir();
+    const store = new OvernightStore({ dataDir });
+    const inserted = store.insert({
+      localDate: "2026-08-28",
+      status: "candidate",
+      goal: "Ship the overnight sqlite row",
+      finishCondition: "vitest overnight-store is green",
+      workAi: "codex",
+      verifyAi: "claude",
+      stallHours: 2,
+      decisionsLog: "chose sqlite over json",
+    });
+
+    expect(inserted).toMatchObject({
+      localDate: "2026-08-28",
+      status: "candidate",
+      goal: "Ship the overnight sqlite row",
+      finishCondition: "vitest overnight-store is green",
+      workAi: "codex",
+      verifyAi: "claude",
+      stallHours: 2,
+      decisionsLog: "chose sqlite over json",
+    });
+    expect(inserted.id.length).toBeGreaterThan(0);
+    expect(Number.isFinite(Date.parse(inserted.createdAt))).toBe(true);
+    expect(Number.isFinite(Date.parse(inserted.updatedAt))).toBe(true);
+    expect(store.get(inserted.id)).toEqual(inserted);
+  });
+
+  it("persists across a new OvernightStore on the same dataDir", async () => {
+    const dataDir = await tempDataDir();
+    const first = new OvernightStore({ dataDir });
+    const inserted = first.insert({
+      id: "card-persist-1",
+      localDate: "2026-08-28",
+      status: "running",
+      goal: "Survive restart",
+      finishCondition: "row readable after reopen",
+      workAi: "pi",
+      stallHours: 1.5,
+      decisionsLog: "",
+    });
+
+    const second = new OvernightStore({ dataDir });
+    expect(second.get("card-persist-1")).toEqual(inserted);
+    expect(second.listByLocalDate("2026-08-28")).toEqual([inserted]);
+  });
+
+  it("rejects unknown status and does not create a row", async () => {
+    const dataDir = await tempDataDir();
+    const store = new OvernightStore({ dataDir });
+    expect(() => store.insert({
+      localDate: "2026-08-28",
+      status: "pending" as "candidate",
+      goal: "Should not land",
+      finishCondition: "n/a",
+      workAi: "grok",
+      stallHours: 1,
+      decisionsLog: "",
+    })).toThrow(/상태/u);
+    expect(store.listByLocalDate("2026-08-28")).toEqual([]);
+  });
+
+  it("rejects unknown workAi", async () => {
+    const dataDir = await tempDataDir();
+    const store = new OvernightStore({ dataDir });
+    expect(() => store.insert({
+      localDate: "2026-08-28",
+      status: "candidate",
+      goal: "Should not land",
+      finishCondition: "n/a",
+      workAi: "cursor" as "claude",
+      stallHours: 1,
+      decisionsLog: "",
+    })).toThrow(/workAi/u);
+    expect(store.listByLocalDate("2026-08-28")).toEqual([]);
+  });
+
+  it("defaults omitted verifyAi to workAi", async () => {
+    const dataDir = await tempDataDir();
+    const store = new OvernightStore({ dataDir });
+    const inserted = store.insert({
+      localDate: "2026-08-28",
+      status: "candidate",
+      goal: "Default verify route",
+      finishCondition: "verifyAi equals workAi",
+      workAi: "grok",
+      stallHours: 3,
+      decisionsLog: "default verify",
+    });
+    expect(inserted.workAi).toBe("grok");
+    expect(inserted.verifyAi).toBe("grok");
+  });
+
+  it("creates overnight and overnight_generation tables", async () => {
+    const dataDir = await tempDataDir();
+    const store = new OvernightStore({ dataDir });
+    const database = new DatabaseSync(store.path(), { readOnly: true });
+    const rows = database.prepare(
+      "SELECT name, sql FROM sqlite_master WHERE type = 'table' AND name IN ('overnight', 'overnight_generation') ORDER BY name",
+    ).all() as Array<{ name: string; sql: string }>;
+    database.close();
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.name).toBe("overnight");
+    expect(rows[0]?.sql).toContain("CREATE TABLE overnight");
+    expect(rows[1]?.name).toBe("overnight_generation");
+    expect(rows[1]?.sql).toContain("CREATE TABLE overnight_generation");
+  });
+
+  it("upserts overnight_generation by local_date", async () => {
+    const dataDir = await tempDataDir();
+    const store = new OvernightStore({ dataDir });
+    expect(store.recordGeneration({
+      localDate: "2026-08-28",
+      generatedAt: "2026-08-28T12:00:00.000Z",
+    })).toEqual({
+      localDate: "2026-08-28",
+      generatedAt: "2026-08-28T12:00:00.000Z",
+    });
+    expect(store.recordGeneration({
+      localDate: "2026-08-28",
+      generatedAt: "2026-08-28T21:00:00.000Z",
+    })).toEqual({
+      localDate: "2026-08-28",
+      generatedAt: "2026-08-28T21:00:00.000Z",
+    });
+    expect(store.getGeneration("2026-08-28")).toEqual({
+      localDate: "2026-08-28",
+      generatedAt: "2026-08-28T21:00:00.000Z",
+    });
+  });
+
+  it("rejects an empty goal and does not insert a blank row", async () => {
+    const dataDir = await tempDataDir();
+    const store = new OvernightStore({ dataDir });
+    expect(() => store.insert({
+      localDate: "2026-08-28",
+      status: "candidate",
+      goal: "   ",
+      finishCondition: "n/a",
+      workAi: "claude",
+      stallHours: 1,
+      decisionsLog: "",
+    })).toThrow(/goal/u);
+    expect(store.listByLocalDate("2026-08-28")).toEqual([]);
+  });
+});
+
+async function tempDataDir() {
+  const directory = await mkdtemp(join(tmpdir(), "gos-overnight-store-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}

--- a/electron/runtime/overnight-store.ts
+++ b/electron/runtime/overnight-store.ts
@@ -1,0 +1,226 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import {
+  isOvernightExecutionProvider,
+  isOvernightStatus,
+  type OvernightExecutionProvider,
+  type OvernightGenerationRecord,
+  type OvernightRecord,
+  type OvernightStatus,
+  OVERNIGHT_STATUSES,
+} from "../../src/shared/contracts";
+
+const STATUS_CHECK = OVERNIGHT_STATUSES.map((status) => `'${status}'`).join(", ");
+
+export interface OvernightInsertInput {
+  id?: string;
+  localDate: string;
+  status: OvernightStatus;
+  goal: string;
+  finishCondition: string;
+  workAi: OvernightExecutionProvider;
+  verifyAi?: OvernightExecutionProvider;
+  stallHours: number;
+  decisionsLog: string;
+}
+
+export class OvernightStore {
+  private readonly databasePath: string;
+  private readonly database: DatabaseSync;
+
+  constructor(options: { dataDir: string }) {
+    const overnightDir = resolve(options.dataDir, "overnight");
+    mkdirSync(overnightDir, { recursive: true });
+    this.databasePath = join(overnightDir, "overnights.sqlite");
+    this.database = new DatabaseSync(this.databasePath);
+    this.database.exec(`
+      CREATE TABLE IF NOT EXISTS overnight (
+        id TEXT PRIMARY KEY NOT NULL,
+        local_date TEXT NOT NULL,
+        status TEXT NOT NULL CHECK(status IN (${STATUS_CHECK})),
+        goal TEXT NOT NULL,
+        finish_condition TEXT NOT NULL,
+        work_ai TEXT NOT NULL,
+        verify_ai TEXT NOT NULL,
+        stall_hours REAL NOT NULL,
+        decisions_log TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS overnight_generation (
+        local_date TEXT PRIMARY KEY NOT NULL,
+        generated_at TEXT NOT NULL
+      );
+    `);
+  }
+
+  path(): string {
+    return this.databasePath;
+  }
+
+  insert(input: OvernightInsertInput): OvernightRecord {
+    const goal = requireNonEmptyText(input.goal, "goal");
+    const status = requireOvernightStatus(input.status);
+    const workAi = requireOvernightExecutionProvider(input.workAi, "workAi");
+    const verifyAi = input.verifyAi === undefined
+      ? workAi
+      : requireOvernightExecutionProvider(input.verifyAi, "verifyAi");
+    const localDate = requireNonEmptyText(input.localDate, "localDate");
+    const finishCondition = requireText(input.finishCondition, "finishCondition");
+    const decisionsLog = requireText(input.decisionsLog, "decisionsLog");
+    const stallHours = requireFiniteNumber(input.stallHours, "stallHours");
+    const id = input.id === undefined ? randomUUID() : requireNonEmptyText(input.id, "id");
+    const now = new Date().toISOString();
+
+    try {
+      this.database.prepare(`
+        INSERT INTO overnight (
+          id, local_date, status, goal, finish_condition, work_ai, verify_ai,
+          stall_hours, decisions_log, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        id,
+        localDate,
+        status,
+        goal,
+        finishCondition,
+        workAi,
+        verifyAi,
+        stallHours,
+        decisionsLog,
+        now,
+        now,
+      );
+    } catch (reason) {
+      if (isSqliteConstraint(reason)) {
+        throw new Error("Overnight 목적 카드 상태가 올바르지 않습니다.");
+      }
+      throw reason;
+    }
+
+    const row = this.database.prepare("SELECT * FROM overnight WHERE id = ?").get(id);
+    return parseOvernightRecord(row);
+  }
+
+  get(id: string): OvernightRecord | undefined {
+    const row = this.database.prepare("SELECT * FROM overnight WHERE id = ?").get(id);
+    if (row === undefined) return undefined;
+    return parseOvernightRecord(row);
+  }
+
+  listByLocalDate(localDate: string): OvernightRecord[] {
+    const rows = this.database.prepare(
+      "SELECT * FROM overnight WHERE local_date = ? ORDER BY created_at ASC, id ASC",
+    ).all(localDate);
+    return rows.map((row) => parseOvernightRecord(row));
+  }
+
+  recordGeneration(input: { localDate: string; generatedAt: string }): OvernightGenerationRecord {
+    const localDate = requireNonEmptyText(input.localDate, "localDate");
+    const generatedAt = requireNonEmptyText(input.generatedAt, "generatedAt");
+    this.database.prepare(`
+      INSERT INTO overnight_generation (local_date, generated_at)
+      VALUES (?, ?)
+      ON CONFLICT(local_date) DO UPDATE SET generated_at = excluded.generated_at
+    `).run(localDate, generatedAt);
+    const recorded = this.getGeneration(localDate);
+    if (!recorded) throw new Error("Overnight generation row was not persisted.");
+    return recorded;
+  }
+
+  getGeneration(localDate: string): OvernightGenerationRecord | undefined {
+    const row = this.database.prepare(
+      "SELECT local_date, generated_at FROM overnight_generation WHERE local_date = ?",
+    ).get(localDate);
+    if (row === undefined) return undefined;
+    return parseOvernightGenerationRecord(row);
+  }
+}
+
+function parseOvernightRecord(row: unknown): OvernightRecord {
+  if (!isRecord(row)) throw new Error("Overnight row is not an object.");
+  const status = requireOvernightStatus(row.status);
+  assertStatusExhaustive(status);
+  return {
+    id: requireNonEmptyText(row.id, "id"),
+    localDate: requireNonEmptyText(row.local_date, "local_date"),
+    status,
+    goal: requireNonEmptyText(row.goal, "goal"),
+    finishCondition: requireText(row.finish_condition, "finish_condition"),
+    workAi: requireOvernightExecutionProvider(row.work_ai, "work_ai"),
+    verifyAi: requireOvernightExecutionProvider(row.verify_ai, "verify_ai"),
+    stallHours: requireFiniteNumber(row.stall_hours, "stall_hours"),
+    decisionsLog: requireText(row.decisions_log, "decisions_log"),
+    createdAt: requireNonEmptyText(row.created_at, "created_at"),
+    updatedAt: requireNonEmptyText(row.updated_at, "updated_at"),
+  };
+}
+
+function parseOvernightGenerationRecord(row: unknown): OvernightGenerationRecord {
+  if (!isRecord(row)) throw new Error("Overnight generation row is not an object.");
+  return {
+    localDate: requireNonEmptyText(row.local_date, "local_date"),
+    generatedAt: requireNonEmptyText(row.generated_at, "generated_at"),
+  };
+}
+
+function assertStatusExhaustive(status: OvernightStatus): void {
+  switch (status) {
+    case "candidate":
+    case "deleted":
+    case "cancelled":
+    case "running":
+    case "ran":
+      return;
+    default: {
+      const _exhaustive: never = status;
+      throw new Error(`Unhandled Overnight status: ${String(_exhaustive)}`);
+    }
+  }
+}
+
+function requireOvernightStatus(value: unknown): OvernightStatus {
+  if (!isOvernightStatus(value)) {
+    throw new Error("Overnight 목적 카드 상태가 올바르지 않습니다.");
+  }
+  return value;
+}
+
+function requireOvernightExecutionProvider(value: unknown, label: string): OvernightExecutionProvider {
+  if (!isOvernightExecutionProvider(value)) {
+    throw new Error(`Overnight ${label} 값이 올바르지 않습니다.`);
+  }
+  return value;
+}
+
+function requireNonEmptyText(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`Overnight ${label} 값이 올바르지 않습니다.`);
+  }
+  return value;
+}
+
+function requireText(value: unknown, label: string): string {
+  if (typeof value !== "string") {
+    throw new Error(`Overnight ${label} 값이 올바르지 않습니다.`);
+  }
+  return value;
+}
+
+function requireFiniteNumber(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`Overnight ${label} 값이 올바르지 않습니다.`);
+  }
+  return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isSqliteConstraint(reason: unknown): boolean {
+  if (typeof reason !== "object" || reason === null || !("code" in reason)) return false;
+  return Reflect.get(reason, "code") === "ERR_SQLITE_ERROR";
+}

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -15,6 +15,34 @@ export function isOvernightExecutionProvider(value: unknown): value is Overnight
   return typeof value === "string"
     && (OVERNIGHT_EXECUTION_PROVIDERS as readonly string[]).includes(value);
 }
+
+export const OVERNIGHT_STATUSES = ["candidate", "deleted", "cancelled", "running", "ran"] as const;
+export type OvernightStatus = typeof OVERNIGHT_STATUSES[number];
+
+export function isOvernightStatus(value: unknown): value is OvernightStatus {
+  return typeof value === "string"
+    && (OVERNIGHT_STATUSES as readonly string[]).includes(value);
+}
+
+export interface OvernightRecord {
+  id: string;
+  localDate: string;
+  status: OvernightStatus;
+  goal: string;
+  finishCondition: string;
+  workAi: OvernightExecutionProvider;
+  verifyAi: OvernightExecutionProvider;
+  stallHours: number;
+  decisionsLog: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface OvernightGenerationRecord {
+  localDate: string;
+  generatedAt: string;
+}
+
 export type OvernightCandidateOrigin = "continuation" | "follow_up" | "proactive" | "batch" | "routine";
 export type OvernightDisposition = "recommend" | "clarify" | "no_run";
 export type OvernightRequestKind = "discover" | "goal";


### PR DESCRIPTION
Closes #30.

## Why

Purpose cards need a durable local row before 21:00 generation or Overnight tab work can land. The JSON portfolio ledger is approval and run authority. Mixing candidate identity into those files would split one product idea.

## Scope

Adds `OvernightRecord`, `OvernightStatus`, and `OvernightGenerationRecord` in `src/shared/contracts.ts`. Adds `OvernightStore` in `electron/runtime/overnight-store.ts` at `{dataDir}/overnight/overnights.sqlite`. `MorrowService` opens that store in its constructor. ADR `docs/adr/0055-overnight-sqlite-row.md` records the split. `OvernightPortfolioLedger` is unchanged. No IPC, UI, Start, or kanban table.

## Tradeoffs

Two stores exist on disk. SQLite holds editable purpose cards. JSON still holds fingerprints and run claims. Replacing the ledger is a later program, not this PR.

## Blast Radius

Every `MorrowService` construct now creates the sqlite file under `dataDir`. Isolated tests that construct `MorrowService` get an extra empty database. Renderer and Start are untouched.

## Verification

Ran `npx vitest run electron/runtime/overnight-store.test.ts` in the worktree. 8 passed. Ran `./node_modules/.bin/tsc -p tsconfig.electron.json`. Exit 0. Live Electron `sqlite3` dump is not run in this PR. Isolated launch still needs GitHub identity. Constructor open is covered by `CREATE TABLE` assertions against the real file.