### PR TITLE
Overnight 목적 카드를 SQLite 한 줄로 저장한다

### DIFF
--- a/docs/adr/0055-overnight-sqlite-purpose-cards.md
+++ b/docs/adr/0055-overnight-sqlite-purpose-cards.md
@@ -1,0 +1,52 @@
+# ADR 0055: Overnight SQLite purpose-card store
+
+- Status: accepted
+- Written: 2026-08-28
+- Contract baseline: 2026-08-28
+- Relates to: [ADR 0053: Provider-neutral Overnight portfolio](0053-provider-neutral-overnight-portfolio.md),
+  [ADR 0054: Overnight launches through four execution routes](0054-four-overnight-execution-routes.md)
+
+## Context
+
+Overnight already freezes approved work in `OvernightPortfolioLedger` JSON under
+`{dataDir}/overnight/portfolios/`. That ledger owns single-use approval,
+containment hashes, and run receipts. Editable purpose cards for a local night
+do not fit that frozen lifetime: candidates are revised, discarded, and only
+later become running work. Mixing those two lifetimes in one JSON store would
+conflate editable drafts with immutable receipts and invite transcript-adjacent
+fields into the ledger.
+
+The product model remains one Overnight equals one purpose card. A local date
+holds zero or more cards. ISSUE-1 needs a durable editable record beside the
+ledger without inventing a second Overnight product.
+
+## Decision
+
+Add `{dataDir}/overnight/overnights.sqlite` with tables `overnight_generation`
+and `overnight` for editable purpose cards.
+
+- One `overnight` row is one Overnight purpose card.
+- Cards enter through dated generations (`commitGeneration`) rather than free-form
+  CRUD inserts.
+- Status is the closed set `candidate | deleted | cancelled | running | ran`,
+  enforced by SQLite `CHECK` and named lifecycle transitions
+  (`discard`, `cancel`, `beginRun`, `markRan`). There is no public `setStatus`.
+- `work_ai` and `verify_ai` are `OvernightExecutionProvider` values from ADR 0054.
+- `decisions_log` stores structured decision entries only. Transcripts, tool
+  logs, and model dumps are rejected at the sqlite parse boundary.
+- `OvernightPortfolioLedger` remains authoritative for frozen approval and run
+  receipts. ISSUE-1 does not replace or migrate the JSON ledger.
+- `MorrowService` constructs the store next to the ledger and calls `open()` at
+  the start of `initializeOnce` so the sqlite file exists after launch even when
+  later runtime setup fails.
+- Public card types live in `src/shared/contracts.ts` for a later renderer.
+
+## Consequences
+
+- Launch creates `{dataDir}/overnight/overnights.sqlite` without requiring a
+  generate or Overnight UI path.
+- Illegal status strings fail at write time through CHECK and typed transitions.
+- Dual persistence (JSON ledger + sqlite store) remains until a later ADR
+  decides how candidates hand off into frozen portfolio approval.
+- Regeneration or supersede policy for a second generation on the same date is
+  deferred; prior generations stay readable via `listCards`.

--- a/electron/runtime/morrow-service.local-verify.test.ts
+++ b/electron/runtime/morrow-service.local-verify.test.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -97,6 +98,7 @@ describe("local verify tonight plan", () => {
     });
     try {
       await service.initialize();
+      expect(existsSync(join(dataDir, "overnight", "overnights.sqlite"))).toBe(true);
       const bootstrap = await service.bootstrap();
       expect(bootstrap.models).toHaveLength(0);
       expect(proposals).toHaveLength(1);

--- a/electron/runtime/morrow-service.ts
+++ b/electron/runtime/morrow-service.ts
@@ -53,6 +53,7 @@ import {
   OvernightPortfolioLedger,
   type OvernightPortfolioAssessmentRecord,
 } from "./overnight-portfolio-ledger";
+import { OvernightStore } from "./overnight-store";
 import {
   OvernightPortfolioService,
   type OvernightPortfolioContainmentControl,
@@ -294,6 +295,7 @@ export interface MorrowServiceOptions {
   overnightPortfolioReadiness?: OvernightPortfolioReadiness;
   overnightProviderVerification?: OvernightProviderVerificationPort;
   overnightProviderControlPlane?: MorrowOvernightProviderControlPlaneFactory;
+  overnightStore?: OvernightStore;
 }
 
 export interface OvernightProviderVerificationPort {
@@ -318,6 +320,7 @@ export class MorrowService {
   private readonly configureRuntime?: (runtime: ModelRuntime) => Promise<void> | void;
   private readonly contextHome?: string;
   private readonly overnightPortfolio: MorrowPortfolioService;
+  private readonly overnightStore: OvernightStore;
   private readonly overnightPortfolioReadiness: OvernightPortfolioReadiness;
   private readonly overnightProviderVerification?: OvernightProviderVerificationPort;
   private readonly providerVerification = new Map<OvernightExecutionProvider, OvernightProviderVerificationSummary>();
@@ -361,6 +364,8 @@ export class MorrowService {
     this.overnightContextEvaluator = options.overnightContextEvaluator ?? evaluateOvernightContext;
     this.overnightContextModelPort = options.overnightContextModelPort;
     const portfolioLedger = new OvernightPortfolioLedger({ dataDir: options.dataDir });
+    this.overnightStore = options.overnightStore
+      ?? new OvernightStore({ dataDir: options.dataDir });
     const providerControlPlane = options.overnightProviderControlPlane?.create({
       approvalClaims: {
         consume: (input) => portfolioLedger.consumeApprovedLaunchClaim(input),
@@ -410,6 +415,9 @@ export class MorrowService {
 
   private async initializeOnce() {
     try {
+      // Create overnights.sqlite before ModelRuntime so launch leaves the file
+      // even when later preference or runtime setup fails.
+      this.overnightStore.open();
       const preferences = await this.readPreferences();
       this.language = preferences.language;
       this.onboardingComplete = preferences.onboardingComplete;

--- a/electron/runtime/overnight-store.test.ts
+++ b/electron/runtime/overnight-store.test.ts
@@ -1,0 +1,210 @@
+import { existsSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  parseOvernightLocalDate,
+  type OvernightCardDraft,
+} from "../../src/shared/contracts";
+import { OvernightStore } from "./overnight-store";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+async function setup(options?: { now?: () => Date; createId?: () => string }) {
+  const dataDir = await mkdtemp(join(tmpdir(), "overnight-store-"));
+  temporaryDirectories.push(dataDir);
+  const store = new OvernightStore({
+    dataDir,
+    now: options?.now ?? (() => new Date("2026-08-28T12:00:00.000Z")),
+    createId: options?.createId,
+  });
+  store.open();
+  return { dataDir, store };
+}
+
+function draft(overrides?: Partial<OvernightCardDraft>): OvernightCardDraft {
+  return {
+    goal: "Ship OvernightStore with tests and ADR 0055",
+    finishCondition: "vitest green; stranger can open the sqlite file after launch",
+    workAi: "codex",
+    verifyAi: "claude",
+    stallHours: 2,
+    decisionsLog: [
+      { at: "2026-08-28T12:00:00.000Z", kind: "proposed", note: "from daily context" },
+    ],
+    ...overrides,
+  };
+}
+
+describe("OvernightStore", () => {
+  it("inserts a candidate via commitGeneration and round-trips fields", async () => {
+    const { store } = await setup();
+    const localDate = parseOvernightLocalDate("2026-08-28");
+    const generation = store.commitGeneration({
+      localDate,
+      cards: [draft({
+        goal: "round-trip goal",
+        finishCondition: "round-trip finish",
+        workAi: "grok",
+        verifyAi: "pi",
+        stallHours: 0,
+        decisionsLog: [
+          { at: "2026-08-28T11:00:00.000Z", kind: "proposed", note: "seed" },
+        ],
+      })],
+    });
+
+    expect(generation.cards).toHaveLength(1);
+    const inserted = generation.cards[0];
+    expect(inserted?.status).toBe("candidate");
+    expect(inserted?.localDate).toBe(localDate);
+    expect(inserted?.generationId).toBe(generation.id);
+
+    const card = store.getCard(inserted!.id);
+    expect(card).toEqual({
+      id: inserted!.id,
+      generationId: generation.id,
+      localDate,
+      status: "candidate",
+      goal: "round-trip goal",
+      finishCondition: "round-trip finish",
+      workAi: "grok",
+      verifyAi: "pi",
+      stallHours: 0,
+      decisionsLog: [
+        { at: "2026-08-28T11:00:00.000Z", kind: "proposed", note: "seed" },
+      ],
+      createdAt: "2026-08-28T12:00:00.000Z",
+      updatedAt: "2026-08-28T12:00:00.000Z",
+    });
+  });
+
+  it("rejects raw SQL INSERT of unknown status at the sqlite boundary", async () => {
+    const { store, dataDir } = await setup();
+    store.close();
+
+    const database = new DatabaseSync(join(dataDir, "overnight", "overnights.sqlite"));
+    database.exec("PRAGMA foreign_keys = ON");
+    database.prepare(`
+      INSERT INTO overnight_generation (id, local_date, created_at)
+      VALUES ('gen-1', '2026-08-28', '2026-08-28T12:00:00.000Z')
+    `).run();
+
+    expect(() => {
+      database.prepare(`
+        INSERT INTO overnight (
+          id, generation_id, local_date, status, goal, finish_condition,
+          work_ai, verify_ai, stall_hours, decisions_log, created_at, updated_at
+        ) VALUES (
+          'card-queued', 'gen-1', '2026-08-28', 'queued', 'g', 'f',
+          'codex', 'claude', 1, '[]', '2026-08-28T12:00:00.000Z', '2026-08-28T12:00:00.000Z'
+        )
+      `).run();
+    }).toThrow(/CHECK constraint failed/u);
+
+    expect(() => {
+      database.prepare(`
+        INSERT INTO overnight (
+          id, generation_id, local_date, status, goal, finish_condition,
+          work_ai, verify_ai, stall_hours, decisions_log, created_at, updated_at
+        ) VALUES (
+          'card-bogus', 'gen-1', '2026-08-28', 'bogus', 'g', 'f',
+          'codex', 'claude', 1, '[]', '2026-08-28T12:00:00.000Z', '2026-08-28T12:00:00.000Z'
+        )
+      `).run();
+    }).toThrow(/CHECK constraint failed/u);
+
+    expect(() => {
+      database.prepare(`
+        INSERT INTO overnight (
+          id, generation_id, local_date, status, goal, finish_condition,
+          work_ai, verify_ai, stall_hours, decisions_log, created_at, updated_at
+        ) VALUES (
+          'card-orphan', 'missing-gen', '2026-08-28', 'candidate', 'g', 'f',
+          'codex', 'claude', 1, '[]', '2026-08-28T12:00:00.000Z', '2026-08-28T12:00:00.000Z'
+        )
+      `).run();
+    }).toThrow(/FOREIGN KEY constraint failed/u);
+
+    database.close();
+  });
+
+  it("refuses illegal lifecycle transitions", async () => {
+    const { store } = await setup();
+    const localDate = parseOvernightLocalDate("2026-08-28");
+    const generation = store.commitGeneration({ localDate, cards: [draft()] });
+    const cardId = generation.cards[0]!.id;
+
+    expect(() => store.markRan(cardId)).toThrow(/허용되지 않은/u);
+
+    store.discard(cardId);
+    expect(() => store.beginRun(cardId)).toThrow(/허용되지 않은/u);
+  });
+
+  it("open creates the sqlite file and reopen finds the schema", async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), "overnight-store-reopen-"));
+    temporaryDirectories.push(dataDir);
+    const path = join(dataDir, "overnight", "overnights.sqlite");
+
+    const first = new OvernightStore({ dataDir });
+    expect(existsSync(path)).toBe(false);
+    first.open();
+    expect(existsSync(path)).toBe(true);
+    first.close();
+
+    const second = new OvernightStore({ dataDir });
+    second.open();
+    const localDate = parseOvernightLocalDate("2026-08-28");
+    const generation = second.commitGeneration({ localDate, cards: [draft()] });
+    expect(second.getCard(generation.cards[0]!.id)?.goal).toBe(draft().goal);
+    second.close();
+  });
+
+  it("revise updates a candidate and refuses revise on ran", async () => {
+    let nowMs = Date.parse("2026-08-28T12:00:00.000Z");
+    const { store } = await setup({
+      now: () => new Date(nowMs),
+    });
+    const localDate = parseOvernightLocalDate("2026-08-28");
+    const generation = store.commitGeneration({ localDate, cards: [draft()] });
+    const cardId = generation.cards[0]!.id;
+
+    nowMs = Date.parse("2026-08-28T13:00:00.000Z");
+    const revised = store.revise(cardId, {
+      goal: "updated goal",
+      appendDecisions: [
+        { at: "2026-08-28T13:00:00.000Z", kind: "revised", note: "tighten finish" },
+      ],
+    });
+    expect(revised.goal).toBe("updated goal");
+    expect(revised.finishCondition).toBe(draft().finishCondition);
+    expect(revised.decisionsLog).toEqual([
+      { at: "2026-08-28T12:00:00.000Z", kind: "proposed", note: "from daily context" },
+      { at: "2026-08-28T13:00:00.000Z", kind: "revised", note: "tighten finish" },
+    ]);
+    expect(revised.updatedAt).toBe("2026-08-28T13:00:00.000Z");
+
+    store.beginRun(cardId);
+    store.markRan(cardId);
+    expect(() => store.revise(cardId, { goal: "too late" })).toThrow(/후보 상태가 아닌/u);
+  });
+
+  it("discard is idempotent", async () => {
+    const { store } = await setup();
+    const localDate = parseOvernightLocalDate("2026-08-28");
+    const generation = store.commitGeneration({ localDate, cards: [draft()] });
+    const cardId = generation.cards[0]!.id;
+
+    const first = store.discard(cardId);
+    expect(first.status).toBe("deleted");
+    const second = store.discard(cardId);
+    expect(second).toEqual(first);
+    expect(second.status).toBe("deleted");
+  });
+});

--- a/electron/runtime/overnight-store.ts
+++ b/electron/runtime/overnight-store.ts
@@ -1,0 +1,484 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import {
+  isOvernightDecisionKind,
+  isOvernightExecutionProvider,
+  isOvernightStatus,
+  parseOvernightId,
+  parseOvernightLocalDate,
+  type OvernightCard,
+  type OvernightCardDraft,
+  type OvernightCardRevision,
+  type OvernightDecisionEntry,
+  type OvernightExecutionProvider,
+  type OvernightGeneration,
+  type OvernightGenerationId,
+  type OvernightId,
+  type OvernightLocalDate,
+  type OvernightStatus,
+} from "../../src/shared/contracts";
+
+const DECISION_NOTE_MAX_CHARS = 4_000;
+const TRANSCRIPT_SHAPED_KEYS = new Set([
+  "transcript",
+  "messages",
+  "content",
+  "role",
+  "tool_calls",
+  "toolCalls",
+  "raw",
+]);
+
+export interface CommitOvernightGenerationInput {
+  localDate: OvernightLocalDate;
+  cards: readonly OvernightCardDraft[];
+}
+
+export type OvernightLifecycleCommand =
+  | { type: "discard" }
+  | { type: "cancel" }
+  | { type: "begin_run" }
+  | { type: "mark_ran" };
+
+export interface OvernightStoreOptions {
+  dataDir: string;
+  now?: () => Date;
+  createId?: () => string;
+}
+
+interface GenerationRecord {
+  id: OvernightGenerationId;
+  localDate: OvernightLocalDate;
+  createdAt: string;
+}
+
+/**
+ * Single source of truth for legal edges. Idempotent when `from` already equals
+ * the command's target. Illegal edges throw (Korean product error string).
+ */
+export function overnightNextStatus(
+  from: OvernightStatus,
+  command: OvernightLifecycleCommand,
+): OvernightStatus {
+  switch (command.type) {
+    case "discard":
+      if (from === "candidate" || from === "deleted") return "deleted";
+      break;
+    case "cancel":
+      if (from === "candidate" || from === "running" || from === "cancelled") return "cancelled";
+      break;
+    case "begin_run":
+      if (from === "candidate" || from === "running") return "running";
+      break;
+    case "mark_ran":
+      if (from === "running" || from === "ran") return "ran";
+      break;
+    default: {
+      const _exhaustive: never = command;
+      return _exhaustive;
+    }
+  }
+  throw new Error("Overnight 작업 상태를 허용되지 않은 방향으로 바꿀 수 없습니다.");
+}
+
+function parseOvernightGenerationId(value: string): OvernightGenerationId {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error("Invalid OvernightGenerationId");
+  }
+  return value as OvernightGenerationId;
+}
+
+function assertFiniteNonNegativeStallHours(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new Error("stallHours는 0 이상의 숫자여야 합니다.");
+  }
+  return value;
+}
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== "string") {
+    throw new Error(`${field}가 올바르지 않습니다.`);
+  }
+  return value;
+}
+
+function asRecord(value: unknown, label: string): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} 행이 올바르지 않습니다.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function parseDecisionEntry(value: unknown): OvernightDecisionEntry {
+  const record = asRecord(value, "decisions_log");
+  for (const key of Object.keys(record)) {
+    if (TRANSCRIPT_SHAPED_KEYS.has(key)) {
+      throw new Error("decisions_log에 transcript 형태의 데이터를 저장할 수 없습니다.");
+    }
+  }
+  const { at, kind, note } = record;
+  if (typeof at !== "string" || at.length === 0) {
+    throw new Error("decisions_log 항목의 at이 올바르지 않습니다.");
+  }
+  if (!isOvernightDecisionKind(kind)) {
+    throw new Error("decisions_log 항목의 kind가 올바르지 않습니다.");
+  }
+  if (typeof note !== "string") {
+    throw new Error("decisions_log 항목의 note가 올바르지 않습니다.");
+  }
+  if (note.length > DECISION_NOTE_MAX_CHARS) {
+    throw new Error("decisions_log note가 너무 깁니다.");
+  }
+  return { at, kind, note };
+}
+
+function parseDecisionsLog(raw: string): OvernightDecisionEntry[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error("decisions_log JSON을 해석하지 못했습니다.");
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error("decisions_log는 배열이어야 합니다.");
+  }
+  return parsed.map(parseDecisionEntry);
+}
+
+function serializeDecisionsLog(entries: readonly OvernightDecisionEntry[]): string {
+  const normalized = entries.map(parseDecisionEntry);
+  return JSON.stringify(normalized);
+}
+
+function requireProvider(value: unknown, field: string): OvernightExecutionProvider {
+  if (!isOvernightExecutionProvider(value)) {
+    throw new Error(`${field}는 Overnight 실행 provider여야 합니다.`);
+  }
+  return value;
+}
+
+function parseOvernightRow(value: unknown): OvernightCard {
+  const row = asRecord(value, "overnight");
+  const status = row.status;
+  if (!isOvernightStatus(status)) {
+    throw new Error(`알 수 없는 Overnight 상태입니다: ${String(status)}`);
+  }
+  return {
+    id: parseOvernightId(requireString(row.id, "id")),
+    generationId: parseOvernightGenerationId(requireString(row.generation_id, "generation_id")),
+    localDate: parseOvernightLocalDate(requireString(row.local_date, "local_date")),
+    status,
+    goal: requireString(row.goal, "goal"),
+    finishCondition: requireString(row.finish_condition, "finish_condition"),
+    workAi: requireProvider(row.work_ai, "workAi"),
+    verifyAi: requireProvider(row.verify_ai, "verifyAi"),
+    stallHours: assertFiniteNonNegativeStallHours(row.stall_hours),
+    decisionsLog: parseDecisionsLog(requireString(row.decisions_log, "decisions_log")),
+    createdAt: requireString(row.created_at, "created_at"),
+    updatedAt: requireString(row.updated_at, "updated_at"),
+  };
+}
+
+function parseGenerationRow(value: unknown): GenerationRecord {
+  const row = asRecord(value, "overnight_generation");
+  return {
+    id: parseOvernightGenerationId(requireString(row.id, "id")),
+    localDate: parseOvernightLocalDate(requireString(row.local_date, "local_date")),
+    createdAt: requireString(row.created_at, "created_at"),
+  };
+}
+
+/**
+ * Editable Overnight purpose-card store beside OvernightPortfolioLedger.
+ * One card = one Overnight. Status changes only through named lifecycle methods.
+ */
+export class OvernightStore {
+  private readonly dataDir: string;
+  private readonly now: () => Date;
+  private readonly createId: () => string;
+  private database: DatabaseSync | undefined;
+
+  constructor(options: OvernightStoreOptions) {
+    this.dataDir = options.dataDir;
+    this.now = options.now ?? (() => new Date());
+    this.createId = options.createId ?? randomUUID;
+  }
+
+  get databasePath(): string {
+    return join(this.dataDir, "overnight", "overnights.sqlite");
+  }
+
+  open(): void {
+    if (this.database) return;
+    mkdirSync(join(this.dataDir, "overnight"), { recursive: true });
+    const database = new DatabaseSync(this.databasePath);
+    database.exec("PRAGMA foreign_keys = ON");
+    database.exec(`
+      CREATE TABLE IF NOT EXISTS overnight_generation (
+        id TEXT PRIMARY KEY,
+        local_date TEXT NOT NULL,
+        created_at TEXT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS overnight (
+        id TEXT PRIMARY KEY,
+        generation_id TEXT NOT NULL REFERENCES overnight_generation(id),
+        local_date TEXT NOT NULL,
+        status TEXT NOT NULL CHECK (status IN ('candidate','deleted','cancelled','running','ran')),
+        goal TEXT NOT NULL,
+        finish_condition TEXT NOT NULL,
+        work_ai TEXT NOT NULL CHECK (work_ai IN ('claude','codex','grok','pi')),
+        verify_ai TEXT NOT NULL CHECK (verify_ai IN ('claude','codex','grok','pi')),
+        stall_hours REAL NOT NULL CHECK (stall_hours >= 0),
+        decisions_log TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS overnight_local_date_idx ON overnight(local_date);
+      CREATE INDEX IF NOT EXISTS overnight_generation_id_idx ON overnight(generation_id);
+      CREATE INDEX IF NOT EXISTS overnight_generation_local_date_idx ON overnight_generation(local_date);
+    `);
+    this.database = database;
+  }
+
+  close(): void {
+    if (!this.database) return;
+    this.database.close();
+    this.database = undefined;
+  }
+
+  /**
+   * Insert a new generation for `localDate` and N candidate cards in one
+   * transaction. Does not mutate prior generations for that date.
+   */
+  commitGeneration(input: CommitOvernightGenerationInput): OvernightGeneration {
+    const database = this.requireOpen();
+    const localDate = parseOvernightLocalDate(input.localDate);
+    if (input.cards.length === 0) {
+      throw new Error("Overnight generation에는 하나 이상의 카드가 필요합니다.");
+    }
+
+    const generationId = parseOvernightGenerationId(this.createId());
+    const createdAt = this.now().toISOString();
+    const cards: OvernightCard[] = [];
+
+    database.exec("BEGIN");
+    try {
+      database.prepare(
+        "INSERT INTO overnight_generation (id, local_date, created_at) VALUES (?, ?, ?)",
+      ).run(generationId, localDate, createdAt);
+
+      const insertCard = database.prepare(`
+        INSERT INTO overnight (
+          id, generation_id, local_date, status, goal, finish_condition,
+          work_ai, verify_ai, stall_hours, decisions_log, created_at, updated_at
+        ) VALUES (?, ?, ?, 'candidate', ?, ?, ?, ?, ?, ?, ?, ?)
+      `);
+
+      for (const draft of input.cards) {
+        const workAi = requireProvider(draft.workAi, "workAi");
+        const verifyAi = requireProvider(draft.verifyAi, "verifyAi");
+        const stallHours = assertFiniteNonNegativeStallHours(draft.stallHours);
+        const decisionsLog = serializeDecisionsLog(draft.decisionsLog);
+        const id = parseOvernightId(this.createId());
+        insertCard.run(
+          id,
+          generationId,
+          localDate,
+          draft.goal,
+          draft.finishCondition,
+          workAi,
+          verifyAi,
+          stallHours,
+          decisionsLog,
+          createdAt,
+          createdAt,
+        );
+        cards.push(parseOvernightRow({
+          id,
+          generation_id: generationId,
+          local_date: localDate,
+          status: "candidate",
+          goal: draft.goal,
+          finish_condition: draft.finishCondition,
+          work_ai: workAi,
+          verify_ai: verifyAi,
+          stall_hours: stallHours,
+          decisions_log: decisionsLog,
+          created_at: createdAt,
+          updated_at: createdAt,
+        }));
+      }
+
+      database.exec("COMMIT");
+    } catch (reason) {
+      database.exec("ROLLBACK");
+      throw reason;
+    }
+
+    return {
+      id: generationId,
+      localDate,
+      createdAt,
+      cards,
+    };
+  }
+
+  generationForDate(localDate: OvernightLocalDate): OvernightGeneration | undefined {
+    const database = this.requireOpen();
+    const date = parseOvernightLocalDate(localDate);
+    const generationValue = database.prepare(`
+      SELECT id, local_date, created_at
+      FROM overnight_generation
+      WHERE local_date = ?
+      ORDER BY created_at DESC
+      LIMIT 1
+    `).get(date);
+    if (generationValue === undefined) return undefined;
+    const generation = parseGenerationRow(generationValue);
+
+    const rows = database.prepare(`
+      SELECT id, generation_id, local_date, status, goal, finish_condition,
+             work_ai, verify_ai, stall_hours, decisions_log, created_at, updated_at
+      FROM overnight
+      WHERE generation_id = ?
+      ORDER BY created_at ASC
+    `).all(generation.id);
+
+    return {
+      id: generation.id,
+      localDate: generation.localDate,
+      createdAt: generation.createdAt,
+      cards: rows.map(parseOvernightRow),
+    };
+  }
+
+  listCards(localDate: OvernightLocalDate): OvernightCard[] {
+    const database = this.requireOpen();
+    const date = parseOvernightLocalDate(localDate);
+    const rows = database.prepare(`
+      SELECT o.id, o.generation_id, o.local_date, o.status, o.goal, o.finish_condition,
+             o.work_ai, o.verify_ai, o.stall_hours, o.decisions_log, o.created_at, o.updated_at
+      FROM overnight o
+      INNER JOIN overnight_generation g ON g.id = o.generation_id
+      WHERE o.local_date = ?
+      ORDER BY g.created_at DESC, o.created_at ASC
+    `).all(date);
+    return rows.map(parseOvernightRow);
+  }
+
+  getCard(id: OvernightId): OvernightCard | undefined {
+    const database = this.requireOpen();
+    const cardId = parseOvernightId(id);
+    const row = database.prepare(`
+      SELECT id, generation_id, local_date, status, goal, finish_condition,
+             work_ai, verify_ai, stall_hours, decisions_log, created_at, updated_at
+      FROM overnight
+      WHERE id = ?
+    `).get(cardId);
+    return row === undefined ? undefined : parseOvernightRow(row);
+  }
+
+  /** candidate → deleted. Idempotent if already deleted. */
+  discard(id: OvernightId): OvernightCard {
+    return this.applyLifecycle(id, { type: "discard" });
+  }
+
+  /** candidate|running → cancelled. Idempotent if already cancelled. */
+  cancel(id: OvernightId): OvernightCard {
+    return this.applyLifecycle(id, { type: "cancel" });
+  }
+
+  /** candidate → running. Idempotent if already running. */
+  beginRun(id: OvernightId): OvernightCard {
+    return this.applyLifecycle(id, { type: "begin_run" });
+  }
+
+  /** running → ran. Idempotent if already ran. */
+  markRan(id: OvernightId): OvernightCard {
+    return this.applyLifecycle(id, { type: "mark_ran" });
+  }
+
+  /**
+   * Revise editable fields. Only legal while status === "candidate".
+   * Status cannot be patched; use lifecycle methods.
+   */
+  revise(id: OvernightId, patch: OvernightCardRevision): OvernightCard {
+    const database = this.requireOpen();
+    const card = this.requireCard(id);
+    if (card.status !== "candidate") {
+      throw new Error("후보 상태가 아닌 Overnight은 수정할 수 없습니다.");
+    }
+
+    const goal = patch.goal ?? card.goal;
+    const finishCondition = patch.finishCondition ?? card.finishCondition;
+    const workAi = patch.workAi === undefined
+      ? card.workAi
+      : requireProvider(patch.workAi, "workAi");
+    const verifyAi = patch.verifyAi === undefined
+      ? card.verifyAi
+      : requireProvider(patch.verifyAi, "verifyAi");
+    const stallHours = patch.stallHours === undefined
+      ? card.stallHours
+      : assertFiniteNonNegativeStallHours(patch.stallHours);
+    const decisionsLog = serializeDecisionsLog([
+      ...card.decisionsLog,
+      ...(patch.appendDecisions ?? []),
+    ]);
+    const updatedAt = this.now().toISOString();
+
+    database.prepare(`
+      UPDATE overnight
+      SET goal = ?, finish_condition = ?, work_ai = ?, verify_ai = ?,
+          stall_hours = ?, decisions_log = ?, updated_at = ?
+      WHERE id = ?
+    `).run(
+      goal,
+      finishCondition,
+      workAi,
+      verifyAi,
+      stallHours,
+      decisionsLog,
+      updatedAt,
+      card.id,
+    );
+
+    return this.requireCard(card.id);
+  }
+
+  private applyLifecycle(id: OvernightId, command: OvernightLifecycleCommand): OvernightCard {
+    const database = this.requireOpen();
+    const card = this.requireCard(id);
+    const next = overnightNextStatus(card.status, command);
+    if (next === card.status) {
+      return card;
+    }
+
+    const updatedAt = this.now().toISOString();
+    database.prepare(`
+      UPDATE overnight
+      SET status = ?, updated_at = ?
+      WHERE id = ?
+    `).run(next, updatedAt, card.id);
+
+    return this.requireCard(card.id);
+  }
+
+  private requireCard(id: OvernightId): OvernightCard {
+    const card = this.getCard(id);
+    if (!card) {
+      throw new Error("이 Overnight을 찾을 수 없습니다.");
+    }
+    return card;
+  }
+
+  private requireOpen(): DatabaseSync {
+    if (!this.database) {
+      throw new Error("OvernightStore가 열려 있지 않습니다. open()을 먼저 호출하세요.");
+    }
+    return this.database;
+  }
+}

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -16,6 +16,134 @@ export function isOvernightExecutionProvider(value: unknown): value is Overnight
   return typeof value === "string"
     && (OVERNIGHT_EXECUTION_PROVIDERS as readonly string[]).includes(value);
 }
+
+export type OvernightId = string & { readonly __brand: "OvernightId" };
+export type OvernightGenerationId = string & { readonly __brand: "OvernightGenerationId" };
+export type OvernightLocalDate = string & { readonly __brand: "OvernightLocalDate" };
+
+/**
+ * Lifecycle of one purpose card. Encoded in SQLite CHECK and in the transition
+ * table so an illegal status cannot be stored through the public API.
+ */
+export type OvernightStatus =
+  | "candidate"
+  | "deleted"
+  | "cancelled"
+  | "running"
+  | "ran";
+
+export const OVERNIGHT_STATUSES = [
+  "candidate",
+  "deleted",
+  "cancelled",
+  "running",
+  "ran",
+] as const;
+
+/** Structured decision notes only. Never a transcript, tool log, or model dump. */
+export type OvernightDecisionKind =
+  | "proposed"
+  | "revised"
+  | "discarded"
+  | "cancelled"
+  | "started"
+  | "finished";
+
+export const OVERNIGHT_DECISION_KINDS = [
+  "proposed",
+  "revised",
+  "discarded",
+  "cancelled",
+  "started",
+  "finished",
+] as const;
+
+export interface OvernightDecisionEntry {
+  at: string;
+  kind: OvernightDecisionKind;
+  note: string;
+}
+
+export interface OvernightCard {
+  id: OvernightId;
+  generationId: OvernightGenerationId;
+  localDate: OvernightLocalDate;
+  status: OvernightStatus;
+  goal: string;
+  finishCondition: string;
+  workAi: OvernightExecutionProvider;
+  verifyAi: OvernightExecutionProvider;
+  stallHours: number;
+  decisionsLog: readonly OvernightDecisionEntry[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface OvernightGeneration {
+  id: OvernightGenerationId;
+  localDate: OvernightLocalDate;
+  createdAt: string;
+  cards: readonly OvernightCard[];
+}
+
+export interface OvernightCardDraft {
+  goal: string;
+  finishCondition: string;
+  workAi: OvernightExecutionProvider;
+  verifyAi: OvernightExecutionProvider;
+  stallHours: number;
+  decisionsLog: readonly OvernightDecisionEntry[];
+}
+
+/** Editable fields while status === "candidate". Status is not patchable here. */
+export interface OvernightCardRevision {
+  goal?: string;
+  finishCondition?: string;
+  workAi?: OvernightExecutionProvider;
+  verifyAi?: OvernightExecutionProvider;
+  stallHours?: number;
+  /** Appended (not replaced) after parse; caller supplies new entries only. */
+  appendDecisions?: readonly OvernightDecisionEntry[];
+}
+
+const OVERNIGHT_LOCAL_DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/u;
+
+export function parseOvernightLocalDate(value: string): OvernightLocalDate {
+  const match = OVERNIGHT_LOCAL_DATE_PATTERN.exec(value);
+  if (!match) {
+    throw new Error(`Invalid OvernightLocalDate: ${value}`);
+  }
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const probe = new Date(Date.UTC(year, month - 1, day));
+  if (
+    probe.getUTCFullYear() !== year
+    || probe.getUTCMonth() !== month - 1
+    || probe.getUTCDate() !== day
+  ) {
+    throw new Error(`Invalid OvernightLocalDate: ${value}`);
+  }
+  return value as OvernightLocalDate;
+}
+
+export function parseOvernightId(value: string): OvernightId {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error("Invalid OvernightId");
+  }
+  return value as OvernightId;
+}
+
+export function isOvernightStatus(value: unknown): value is OvernightStatus {
+  return typeof value === "string"
+    && (OVERNIGHT_STATUSES as readonly string[]).includes(value);
+}
+
+export function isOvernightDecisionKind(value: unknown): value is OvernightDecisionKind {
+  return typeof value === "string"
+    && (OVERNIGHT_DECISION_KINDS as readonly string[]).includes(value);
+}
+
 export type OvernightCandidateOrigin = "continuation" | "follow_up" | "proactive" | "batch" | "routine";
 export type OvernightDisposition = "recommend" | "clarify" | "no_run";
 export type OvernightRequestKind = "discover" | "goal";


### PR DESCRIPTION
## Why

Overnight 후보를 고치려면 실행 레저와 다른 수명이 필요하다. JSON 레저는 언 승인과 영수증을 연다. 목적 카드는 SQLite 한 줄이다.

## Scope

- `OvernightStore` writes `{dataDir}/overnight/overnights.sqlite`
- tables `overnight` and `overnight_generation`
- status CHECK for `candidate`, `deleted`, `cancelled`, `running`, `ran`
- named transitions `discard`, `cancel`, `beginRun`, `markRan`
- `MorrowService.initializeOnce` opens the file first
- ADR 0055

Not in this PR. 21:00 generate, Overnight tab grid, field editor, stall stop.

## Tradeoffs

JSON 레저와 sqlite를 같이 둔다. 승인 핸드오프는 다음 이슈다.

## Blast Radius

`MorrowService` initialize and new store tests. Renderer unchanged. Start path unchanged.

## Verification

```
npx vitest run electron/runtime/overnight-store.test.ts
```

6 passed. Insert round-trip, unknown status CHECK, illegal transition, reopen schema, revise, idempotent discard, foreign key.

```
npx vitest run electron/runtime/morrow-service.local-verify.test.ts
```

initialize creates `overnights.sqlite`.

Build and landing tests passed. `morrow-service.integration.test.ts` recovery redispatch already fails on `origin/main`. This PR does not change that test.

Supersedes #48, which branches from an older main.

Closes #30