### PR TITLE
feat(overnight): always isolate start in a git worktree

### DIFF
--- a/electron/runtime/overnight-portfolio-service.test.ts
+++ b/electron/runtime/overnight-portfolio-service.test.ts
@@ -294,21 +294,31 @@ function workspaceHarness() {
   return { manager, allocate };
 }
 
-function sharedWorkspaceHarness(): OvernightPortfolioWorkspaceManager {
+function dirtyIsolatedWorkspaceHarness(): OvernightPortfolioWorkspaceManager {
   const snapshot: OvernightWorkspaceSnapshot = {
     root: "/repo",
     repositoryRoot: "/repo",
     repositoryRevision: "a".repeat(40),
     repositoryRelativeRoot: "",
     workspaceKey: "/repo",
-    isolation: "shared",
+    isolation: "isolated",
     reason: "dirty_git_worktree",
   };
-  const allocation = { ...snapshot, executionRoot: "/repo", worktreeKey: "/repo" };
+  const allocate = vi.fn(async (_snapshot: OvernightWorkspaceSnapshot, planId: string, itemId: string) => ({
+    ...snapshot,
+    executionRoot: `/private/worktrees/${planId}/${itemId}`,
+    worktreeKey: `/private/worktrees/${planId}/${itemId}`,
+    branch: `morrow/overnight/${planId}/${itemId}`,
+  }));
   return {
     inspect: vi.fn(async () => snapshot),
-    plannedAllocation: () => allocation,
-    allocate: vi.fn(async () => allocation),
+    plannedAllocation: (_snapshot, planId, itemId) => ({
+      ...snapshot,
+      executionRoot: `/private/worktrees/${planId}/${itemId}`,
+      worktreeKey: `/private/worktrees/${planId}/${itemId}`,
+      branch: `morrow/overnight/${planId}/${itemId}`,
+    }),
+    allocate,
     resultMetadata: overnightWorkspaceResultMetadata,
   };
 }
@@ -493,19 +503,17 @@ describe("Overnight portfolio service", () => {
     expect(setup.dispatchItem).not.toHaveBeenCalled();
   });
 
-  it("serializes independent V3 items that share one approved workspace without persisting its path", async () => {
+  it("keeps dirty git plans isolated in private worktrees without persisting their paths", async () => {
     const setup = await setupService();
     const containment = containmentControlHarness();
-    const shared = sharedWorkspaceHarness();
+    const dirty = dirtyIsolatedWorkspaceHarness();
     const service = new OvernightPortfolioService({
       ...setup.options,
-      workspace: shared,
+      workspace: dirty,
       containmentControl: containment.control,
     });
     const first = candidate("shared-first", "codex", ["codex:shared-first"]);
     const second = candidate("shared-second", "claude", ["claude:shared-second"]);
-    first.writeScopes = ["*"];
-    second.writeScopes = ["*"];
 
     const result = await service.recommend(
       { requestKind: "explicit", candidates: [first, second] },
@@ -515,9 +523,12 @@ describe("Overnight portfolio service", () => {
       ]),
     );
 
-    expect(result.plan).toMatchObject({ peakParallelism: 1, totalMinutes: 120 });
+    expect(result.plan?.items.every((item) => item.isolation === "isolated")).toBe(true);
+    expect(result.plan?.items.map((item) => item.id)).toEqual(["shared-first", "shared-second"]);
+    expect(result.plan).toMatchObject({ peakParallelism: 2, totalMinutes: 60 });
     const authorityText = await readFile(join(setup.dataDir, "overnight", "portfolios", "plans", "plan_20260826.json"), "utf8");
     expect(authorityText).not.toContain('"worktreeKey":"/repo"');
+    expect(authorityText).not.toContain('"integrationStatus":"shared_workspace"');
     expect(authorityText).toContain('"worktreeKey":"path-free:');
   });
 
@@ -605,19 +616,20 @@ describe("Overnight portfolio service", () => {
     expect(result.assessment.candidates).toHaveLength(5);
   });
 
-  it("keeps every discover outcome when one requires an additional result", async () => {
+  it("preserves independent discover outcomes when a cross-worktree dependency is blocked", async () => {
     const ids = ["primary", "second", "third", "required-setup"];
     const sessions = ids.map((id) => session(`codex:${id}`, "codex", `Prepare ${id}`));
     const candidates = ids.map((id) => candidate(id, "codex", [`codex:${id}`]));
     candidates[0].reasonCodes = [...candidates[0].reasonCodes, "explicit_priority"];
     candidates[0].dependencyKeys = ["required-setup"];
     const setup = await setupService();
-    const service = new OvernightPortfolioService({ ...setup.options, workspace: sharedWorkspaceHarness() });
+    const service = new OvernightPortfolioService({ ...setup.options, workspace: dirtyIsolatedWorkspaceHarness() });
 
     const result = await service.recommend({ requestKind: "discover", candidates }, context(sessions));
 
-    expect(result.plan?.items.map((item) => item.stableKey)).toEqual(ids);
-    expect(result.plan?.totalMinutes).toBe(240);
+    expect(result.scopeDecisionReason).toMatch(/의존 작업 결과|차단된 의존 관계/u);
+    expect(result.plan?.items.map((item) => item.stableKey)).toEqual(["second", "third"]);
+    expect(result.assessment.candidates.map((item) => item.stableKey)).toEqual(ids);
   });
 
   it("collapses proposed mutation scopes to the one root-wide approved boundary", async () => {
@@ -1066,7 +1078,7 @@ describe("Overnight portfolio service", () => {
     expect((await setup.service.snapshotPlans()).map((plan) => plan.id)).toEqual([prepared.plan!.id]);
   });
 
-  it("allows a dependency chain when both items execute in the same shared workspace", async () => {
+  it("plans dirty git overnight items as isolated worktrees and blocks cross-worktree dependencies", async () => {
     const sessions = [
       session("codex:first", "codex", "Fix first transition regression"),
       session("grok:second", "grok", "Fix second transition regression"),
@@ -1074,16 +1086,18 @@ describe("Overnight portfolio service", () => {
     const second = candidate("second", "grok", ["grok:second"]);
     second.dependencyKeys = ["first"];
     const setup = await setupService();
-    const service = new OvernightPortfolioService({ ...setup.options, workspace: sharedWorkspaceHarness() });
+    const workspace = dirtyIsolatedWorkspaceHarness();
+    const service = new OvernightPortfolioService({ ...setup.options, workspace });
 
     const prepared = await service.recommend({
       requestKind: "discover",
       candidates: [candidate("first", "codex", ["codex:first"]), second],
     }, context(sessions));
 
-    expect(prepared.scopeDecisionReason).toBeUndefined();
-    expect(prepared.plan?.items.map((item) => item.id)).toEqual(["first", "second"]);
-    expect(prepared.plan?.items.every((item) => item.isolation === "shared")).toBe(true);
+    expect(await workspace.inspect()).toMatchObject({ isolation: "isolated", reason: "dirty_git_worktree" });
+    expect(prepared.scopeDecisionReason).toMatch(/의존 작업 결과|차단된 의존 관계/u);
+    expect(prepared.plan).toBeUndefined();
+    expect(prepared.assessment.candidates.map((item) => item.stableKey)).toEqual(["first", "second"]);
   });
 
   it("recovers an interrupted run without repeating completed work", async () => {

--- a/electron/runtime/overnight-portfolio-service.ts
+++ b/electron/runtime/overnight-portfolio-service.ts
@@ -624,7 +624,7 @@ export class OvernightPortfolioService {
       let resultMetadata: OvernightWorkspaceResultMetadata = {
         executionRoot: "approved-private-root",
         worktreeKey: item.worktreeKey,
-        integrationStatus: item.isolation === "shared" ? "shared_workspace" : "not_integrated",
+        integrationStatus: "not_integrated",
       };
       resultMetadataByItem.set(item.id, resultMetadata);
       const transitioned = await this.ledger.writeItemState(

--- a/electron/runtime/overnight-worktree.test.ts
+++ b/electron/runtime/overnight-worktree.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { execFile } from "node:child_process";
-import { mkdtemp, mkdir, realpath, rm, writeFile } from "node:fs/promises";
+import { access, mkdtemp, mkdir, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -26,6 +26,7 @@ describe("Overnight worktree manager", () => {
     const allocation = await manager.allocate(snapshot, "run-1", "item-1");
     expect(allocation).toEqual(planned);
     expect(allocation.executionRoot).not.toBe(await realpath(fixture.repository));
+    expect(allocation.executionRoot).toContain(join("overnight", "worktrees", "run-1", "item-1"));
     expect(allocation.branch).toBe("morrow/overnight/run-1/item-1");
     expect((await git(["-C", allocation.executionRoot, "rev-parse", "HEAD"])).trim()).toBe(snapshot.repositoryRevision);
     expect(await realpath(join(allocation.executionRoot, "README.md"))).toBe(join(await realpath(allocation.executionRoot), "README.md"));
@@ -49,37 +50,51 @@ describe("Overnight worktree manager", () => {
     expect(await git(["-C", fixture.repository, "status", "--porcelain=v1"])).toBe("");
   });
 
-  it("keeps a dirty or non-git root shared so uncommitted context is not silently dropped", async () => {
+  it("keeps dirty main files in place and still allocates an isolated worktree from the frozen HEAD", async () => {
     const fixture = await gitFixture();
     await writeFile(join(fixture.repository, "README.md"), "dirty\n");
+    await writeFile(join(fixture.repository, "dirty-only.txt"), "uncommitted\n");
     const dirtyManager = new OvernightWorktreeManager({ root: fixture.repository, dataDir: fixture.dataDir });
     const dirty = await dirtyManager.inspect();
-    expect(dirty).toMatchObject({ isolation: "shared", reason: "dirty_git_worktree" });
-    const dirtyAllocation = await dirtyManager.allocate(dirty, "run-2", "item-2");
-    expect(dirtyAllocation.executionRoot).toBe(await realpath(fixture.repository));
-    expect(dirtyManager.resultMetadata(dirtyAllocation)).toEqual({
-      executionRoot: await realpath(fixture.repository),
-      worktreeKey: await realpath(fixture.repository),
-      baseRevision: dirty.repositoryRevision,
-      integrationStatus: "shared_workspace",
-    });
+    expect(dirty).toMatchObject({ isolation: "isolated", reason: "dirty_git_worktree" });
 
-    const plainRoot = join(fixture.base, "plain");
-    await mkdir(plainRoot);
-    const plain = await new OvernightWorktreeManager({ root: plainRoot, dataDir: fixture.dataDir }).inspect();
-    expect(plain).toMatchObject({ isolation: "shared", reason: "not_a_git_worktree" });
+    const dirtyAllocation = await dirtyManager.allocate(dirty, "run-2", "item-2");
+    expect(dirtyAllocation.executionRoot).not.toBe(await realpath(fixture.repository));
+    expect(dirtyAllocation.executionRoot).toContain(join("overnight", "worktrees", "run-2", "item-2"));
+    expect(dirtyAllocation.branch).toBe("morrow/overnight/run-2/item-2");
+    expect((await git(["-C", dirtyAllocation.executionRoot, "rev-parse", "HEAD"])).trim()).toBe(dirty.repositoryRevision);
+    expect(await git(["-C", fixture.repository, "status", "--porcelain=v1"])).toMatch(/dirty-only\.txt/u);
+    expect(await git(["-C", fixture.repository, "status", "--porcelain=v1"])).toMatch(/README\.md/u);
+    await expect(access(join(dirtyAllocation.executionRoot, "dirty-only.txt"))).rejects.toMatchObject({ code: "ENOENT" });
+    expect(await readFile(join(dirtyAllocation.executionRoot, "README.md"), "utf8")).toBe("fixture\n");
+    expect(dirtyManager.resultMetadata(dirtyAllocation)).toEqual({
+      executionRoot: dirtyAllocation.executionRoot,
+      worktreeKey: dirtyAllocation.worktreeKey,
+      branch: "morrow/overnight/run-2/item-2",
+      baseRevision: dirty.repositoryRevision,
+      integrationStatus: "not_integrated",
+    });
   });
 
-  it("canonicalizes a shared root so launch hashes match inspect", async () => {
+  it("refuses to allocate when the root is not a git worktree", async () => {
     const fixture = await gitFixture();
     const plainRoot = join(fixture.base, "plain");
     await mkdir(plainRoot);
     const manager = new OvernightWorktreeManager({ root: plainRoot, dataDir: fixture.dataDir });
-    const inspected = await manager.inspect();
-    const unresolved = { ...inspected, root: plainRoot, workspaceKey: plainRoot };
-    const allocation = await manager.allocate(unresolved, "run-canon", "item-canon");
-    expect(allocation.executionRoot).toBe(inspected.root);
-    expect(allocation.worktreeKey).toBe(inspected.root);
+    const plain = await manager.inspect();
+    expect(plain).toMatchObject({ isolation: "shared", reason: "not_a_git_worktree" });
+    await expect(manager.allocate(plain, "run-plain", "item-plain")).rejects.toThrow(/git 저장소/u);
+    await expect(() => manager.plannedAllocation(plain, "run-plain", "item-plain")).toThrow(/git 저장소/u);
+  });
+
+  it("returns the planned allocation when the same run and item worktree already exists", async () => {
+    const fixture = await gitFixture();
+    const manager = new OvernightWorktreeManager({ root: fixture.repository, dataDir: fixture.dataDir });
+    const snapshot = await manager.inspect();
+    const first = await manager.allocate(snapshot, "run-idempotent", "item-idempotent");
+    const second = await manager.allocate(snapshot, "run-idempotent", "item-idempotent");
+    expect(second).toEqual(first);
+    expect(second.executionRoot).toBe(first.executionRoot);
   });
 
   it("rejects path-like run and item identifiers before creating anything", async () => {
@@ -110,3 +125,4 @@ async function git(args: readonly string[]) {
   const { stdout } = await execFileAsync("git", [...args], { encoding: "utf8", timeout: 10_000 });
   return stdout;
 }
+

--- a/electron/runtime/overnight-worktree.ts
+++ b/electron/runtime/overnight-worktree.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
-import { mkdir, realpath } from "node:fs/promises";
-import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { access, mkdir, realpath } from "node:fs/promises";
+import { dirname, isAbsolute, relative, resolve } from "node:path";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
@@ -31,6 +31,8 @@ export interface OvernightWorkspaceResultMetadata {
 
 export type OvernightGitRunner = (args: readonly string[]) => Promise<string>;
 
+const NOT_A_GIT_ERROR = "Overnight는 git 저장소 안에서만 시작할 수 있습니다.";
+
 export class OvernightWorktreeManager {
   private readonly root: string;
   private readonly dataDir: string;
@@ -58,7 +60,7 @@ export class OvernightWorktreeManager {
         repositoryRevision,
         repositoryRelativeRoot,
         workspaceKey: repositoryRoot,
-        isolation: dirty ? "shared" : "isolated",
+        isolation: "isolated",
         reason: dirty ? "dirty_git_worktree" : "clean_git_worktree",
       };
     } catch {
@@ -68,45 +70,33 @@ export class OvernightWorktreeManager {
 
   async allocate(snapshot: OvernightWorkspaceSnapshot, runId: string, itemId: string): Promise<OvernightWorkspaceAllocation> {
     const root = await realpath(snapshot.root);
-    const canonical = {
-      ...snapshot,
-      root,
-      ...(snapshot.isolation === "shared" ? { workspaceKey: root } : {}),
-    };
+    const canonical = { ...snapshot, root };
+    assertGitWorkspace(canonical);
     const planned = this.plannedAllocation(canonical, runId, itemId);
-    if (canonical.isolation === "shared") {
+    const worktreeRoot = planned.worktreeKey;
+    if (await this.worktreeExists(canonical.repositoryRoot!, worktreeRoot)) {
       return planned;
     }
-    snapshot = canonical;
-    if (!snapshot.repositoryRoot || !snapshot.repositoryRevision || snapshot.repositoryRelativeRoot === undefined) {
-      throw new Error("The approved workspace does not contain a complete frozen git revision.");
-    }
-    const worktreeRoot = planned.worktreeKey;
     await mkdir(dirname(worktreeRoot), { recursive: true, mode: 0o700 });
-    const branch = planned.branch!;
     await this.runGit([
-      "-C", snapshot.repositoryRoot,
-      "worktree", "add", "-b", branch, worktreeRoot, snapshot.repositoryRevision,
+      "-C", canonical.repositoryRoot!,
+      "worktree", "add", "-b", planned.branch!, worktreeRoot, canonical.repositoryRevision!,
     ]);
     return planned;
   }
 
   plannedAllocation(snapshot: OvernightWorkspaceSnapshot, runId: string, itemId: string): OvernightWorkspaceAllocation {
-    if (snapshot.isolation === "shared") {
-      return { ...snapshot, executionRoot: snapshot.root, worktreeKey: snapshot.root };
-    }
-    if (!snapshot.repositoryRoot || !snapshot.repositoryRevision || snapshot.repositoryRelativeRoot === undefined) {
-      throw new Error("The approved workspace does not contain a complete frozen git revision.");
-    }
+    assertGitWorkspace(snapshot);
     const safeRunId = safeSegment(runId, "run id");
     const safeItemId = safeSegment(itemId, "item id");
     const worktreeBase = resolve(this.dataDir, "overnight", "worktrees");
     const worktreeRoot = resolve(worktreeBase, safeRunId, safeItemId);
     assertInside(worktreeBase, worktreeRoot);
-    const executionRoot = resolve(worktreeRoot, snapshot.repositoryRelativeRoot);
+    const executionRoot = resolve(worktreeRoot, snapshot.repositoryRelativeRoot!);
     assertInside(worktreeRoot, executionRoot, true);
     return {
       ...snapshot,
+      isolation: "isolated",
       executionRoot,
       worktreeKey: worktreeRoot,
       branch: `morrow/overnight/${safeRunId}/${safeItemId}`,
@@ -115,6 +105,32 @@ export class OvernightWorktreeManager {
 
   resultMetadata(allocation: OvernightWorkspaceAllocation): OvernightWorkspaceResultMetadata {
     return overnightWorkspaceResultMetadata(allocation);
+  }
+
+  private async worktreeExists(repositoryRoot: string, worktreeRoot: string) {
+    try {
+      await access(worktreeRoot);
+    } catch {
+      return false;
+    }
+    let existing: string;
+    try {
+      existing = await realpath(worktreeRoot);
+    } catch {
+      return false;
+    }
+    const listed = await this.runGit(["-C", repositoryRoot, "worktree", "list", "--porcelain"]);
+    for (const block of listed.split("\n\n")) {
+      const line = block.split("\n").find((entry) => entry.startsWith("worktree "));
+      if (!line) continue;
+      const listedPath = line.slice("worktree ".length);
+      try {
+        if (await realpath(listedPath) === existing) return true;
+      } catch {
+        if (resolve(listedPath) === existing) return true;
+      }
+    }
+    return false;
   }
 }
 
@@ -126,7 +142,7 @@ export function overnightWorkspaceResultMetadata(
     worktreeKey: allocation.worktreeKey,
     ...(allocation.branch ? { branch: allocation.branch } : {}),
     ...(allocation.repositoryRevision ? { baseRevision: allocation.repositoryRevision } : {}),
-    integrationStatus: allocation.isolation === "isolated" ? "not_integrated" : "shared_workspace",
+    integrationStatus: "not_integrated",
   };
 }
 
@@ -142,6 +158,18 @@ function sharedSnapshot(root: string, reason: OvernightWorkspaceSnapshot["reason
     isolation: "shared",
     reason,
   };
+}
+
+function assertGitWorkspace(snapshot: OvernightWorkspaceSnapshot) {
+  if (
+    snapshot.reason === "not_a_git_worktree"
+    || snapshot.isolation === "shared"
+    || !snapshot.repositoryRoot
+    || !snapshot.repositoryRevision
+    || snapshot.repositoryRelativeRoot === undefined
+  ) {
+    throw new Error(NOT_A_GIT_ERROR);
+  }
 }
 
 function safeSegment(value: string, label: string) {


### PR DESCRIPTION
Closes #42. Relates to #34.

## Why

Dirty main used to force Overnight into the user folder. Daytime uncommitted files then sat in the same tree as the night worker. Start should always get a linked worktree from the frozen HEAD.

## Scope

`OvernightWorktreeManager.inspect` still records dirty vs clean. Git roots always have `isolation: "isolated"`. `allocate` always runs `git worktree add -b morrow/overnight/<runId>/<itemId>` under `{dataDir}/overnight/worktrees`. Non-git roots throw. A second allocate of the same ids is a no-op if the worktree already exists.

`overnight-portfolio-service` pre-allocate `integrationStatus` is `not_integrated`. Tests that expected dirty to mean shared were inverted.

Does not change the kanban UI, 21:00 generator, or host-serial board ticket runs.

## Tradeoffs

`isolation: "shared"` remains on the inspect type for non-git reporting. Allocate refuses that snapshot instead of deleting the field.

## Blast Radius

Every Overnight start on a git repo now creates a private worktree, including dirty mains. Non-git launch roots fail closed at start.

## Verification

Ran `npx vitest run electron/runtime/overnight-worktree.test.ts electron/runtime/overnight-portfolio-service.test.ts`. 38 passed. Dirty fixture keeps `dirty-only.txt` on main and absent in the overnight worktree. Ran `tsc -p tsconfig.electron.json`. Exit 0. A live Start against a dirty personal repo was not run.