### PR TITLE
설정 Overnight CLI 검증은 재확인과 Pi 연결 준비 중을 본다

### DIFF
--- a/scripts/verify-god-of-sessions/features/settings-clis.md
+++ b/scripts/verify-god-of-sessions/features/settings-clis.md
@@ -1,12 +1,12 @@
 # Settings CLIs
 
-Settings reports the four official Overnight routes. Claude Code, Codex, and Grok Build use PATH. Pi Agent is listed and not ready. Sign-in happens in the official CLI, not in this screen. There is no Safety check, OS-containment canary, or in-app OAuth for those workers.
+Settings reports the four official Overnight routes. Claude Code, Codex, Grok Build, and the pi terminal CLI use PATH. Opening the screen runs one live re-check (PATH lookup plus sign-in probe) with a visible Checking spinner, and a Check again button re-runs it. Sign-in happens in the official CLI, not in this screen. There is no Safety check, OS-containment canary, or in-app OAuth for those workers.
 
 ## Sub-features
 
 - `four-cli-cards` lists Claude Code, Codex, Grok Build, and Pi Agent.
-- `path-status` shows Ready for Overnight when the CLI is on PATH and signed in, Sign in from Terminal when it is installed but not signed in, or Not installed. Pi shows Not ready for Overnight.
-- `login-hint` keeps a `Copy login` button only when that CLI is not signed in. Commands are `claude auth login`, `codex login`, and `grok login`. Pi has no copy button.
+- `path-status` shows Ready for Overnight when the CLI is on PATH and signed in, Sign in from Terminal when it is installed but not signed in, Not installed when it is missing, or Couldn't check when a completed probe stayed indeterminate. Checking appears only while a live re-check is running. Pi shows Overnight hookup in progress when the pi CLI is installed.
+- `login-hint` keeps a `Copy login` button only when that CLI is not signed in. Commands are `claude auth login`, `codex login`, and `grok login`. A missing pi CLI gets a `Copy install` button with `npm install -g @earendil-works/pi-coding-agent`.
 - `no-safety-check` has no `Safety check` button.
 - `no-overnight-oauth` has no Connect/OAuth control on the Overnight CLI rows. Morrow's separate conversation-model section may still have provider login.
 
@@ -31,6 +31,6 @@ Preconditions:
 
 ## Gotchas
 
-- Morrow's conversation-model block is chat login. Do not treat a Claude chat OAuth button as Overnight CLI OAuth. Pi Agent on Overnight is the conversation SDK, not a PATH CLI.
+- Morrow's conversation-model block is chat login. Do not treat a Claude chat OAuth button as Overnight CLI OAuth. Pi Agent powers Morrow conversations and also ships as the pi terminal CLI; its Overnight dispatch is still gated.
 - Ready for Overnight means PATH plus a signed-in official CLI. It is not a public security claim.
 - Cursor, Hermes, and OpenClaw must not appear as Overnight CLI rows.

--- a/scripts/verify-god-of-sessions/features/settings.md
+++ b/scripts/verify-god-of-sessions/features/settings.md
@@ -6,7 +6,7 @@ Settings is three groups of labeled rows: Morrow, Overnight, and App. It shows t
 
 - `settings-nav` opens Settings from the sidebar or from chat `Connect model`.
 - `settings-morrow` shows the conversation-model summary or open picker, with Change and Disconnect when connected.
-- `settings-clis` lists Claude Code, Codex, Grok Build, and Pi Agent as Ready for Overnight, Sign in from Terminal, Not installed, or Not ready for Overnight.
+- `settings-clis` lists Claude Code, Codex, Grok Build, and Pi Agent as Ready for Overnight, Sign in from Terminal, Not installed, Couldn't check, or (for Pi) Overnight hookup in progress. Opening the screen re-checks live.
 - `settings-app` shows Language, Working folder, and GitHub.
 - `settings-language` toggles English and 한국어.
 
@@ -27,7 +27,7 @@ Preconditions:
 - **Open Settings.** Choose the nav button. Run `click --role button --name "Settings"`. Heading is `Settings`.
 - **Working folder.** Isolated launch sets `MORROW_ROOT`. Require the visible path to equal that disposable workspace from `doctor` output, not the user's checkout and not `/Users/example/godofsessions`. Without `MORROW_ROOT`, Settings shows the installer home; that is the product default, not this recipe.
 - **GitHub.** The App group shows `@` plus a login. Buttons `Manage access` and `Sign out` are present. Do not click Sign out unless the recipe's next step is the identity gate on this same isolated profile.
-- **Overnight.** The section `Overnight` lists the four official routes. Status is `Ready for Overnight`, `Sign in from Terminal`, `Not installed`, or `Not ready for Overnight`. This screen does not log the user into those CLIs.
+- **Overnight.** The section `Overnight` lists the four official routes. Status is `Ready for Overnight`, `Sign in from Terminal`, `Not installed`, `Couldn't check`, or (for Pi) `Overnight hookup in progress`; `Checking` shows only while the live re-check runs. This screen does not log the user into those CLIs.
 - **Language.** Choose `한국어`, then require Korean chrome (`Morrow에게 묻기`, heading `설정`). Choose `English` to restore the recipe language before other features.
 - **Proof.** Screenshot and aria named `settings` showing the working-folder path and the GitHub login. Redact nothing in the screenshot if the login is a disposable verify account. Do not copy the user's personal login screenshot into the git tree. Evidence stays under `/tmp/godofsessions-verify/`.
 

--- a/scripts/verify-god-of-sessions/scripts/drive.mjs
+++ b/scripts/verify-god-of-sessions/scripts/drive.mjs
@@ -151,12 +151,15 @@ async function proveOvernightBoard(page, app) {
 async function proveSettingsClis(page) {
   await page.getByRole("button", { name: "Settings" }).click();
   await page.getByRole("heading", { name: "Overnight", exact: true }).waitFor();
+  // Opening Settings triggers a live re-check; wait for it to settle.
+  await page.getByText("Ready for Overnight").first().waitFor();
   const body = await page.locator("body").innerText();
   for (const name of ["Claude Code", "Codex", "Grok Build", "Pi Agent"]) assert.match(body, new RegExp(name));
   assert.doesNotMatch(body, /Installed means the command is on PATH/);
   assert.match(body, /Ready for Overnight/);
   assert.match(body, /Sign in from Terminal/);
-  assert.match(body, /Not ready for Overnight/);
+  assert.match(body, /Overnight hookup in progress|Not installed/);
+  assert.doesNotMatch(body, /Not ready for Overnight|Conversation SDK only/);
   assert.doesNotMatch(body, /Bundled with Morrow/i);
   assert.doesNotMatch(body, /Safety check/);
   assert.doesNotMatch(body, /OS containment/i);
@@ -171,7 +174,8 @@ async function proveSettingsClis(page) {
   const korean = await page.locator("body").innerText();
   assert.match(korean, /Overnight에 사용 가능/);
   assert.match(korean, /로그인 필요/);
-  assert.match(korean, /Overnight에 아직 없음/);
+  assert.match(korean, /Overnight 연결 준비 중|없음/);
+  assert.doesNotMatch(korean, /Overnight에 아직 없음|대화 SDK/);
   assert.doesNotMatch(korean, /하나면 Morrow가 말합니다/);
   assert.doesNotMatch(korean, /설치됨은 PATH에서/);
   assert.doesNotMatch(korean, /화면만 바꿉니다/);
@@ -235,7 +239,7 @@ async function installSyntheticIpc(electronApp, fixture) {
       "morrow:bootstrap", "morrow:overnight-snapshot", "morrow:start-conversation", "morrow:open-conversation", "morrow:send-message",
       "morrow:abort", "morrow:set-model", "morrow:set-thinking", "morrow:answer-approval",
       "morrow:connect-provider", "morrow:answer-auth", "morrow:disconnect-provider", "morrow:finish-onboarding",
-      "morrow:refresh-daily-context", "morrow:prepare-overnight-portfolio", "morrow:start-overnight-portfolio", "morrow:stop-overnight-portfolio",
+      "morrow:refresh-daily-context", "morrow:refresh-overnight-providers", "morrow:prepare-overnight-portfolio", "morrow:start-overnight-portfolio", "morrow:stop-overnight-portfolio",
       "morrow:verify-overnight-provider", "morrow:open-external",
       "morrow:list-overnight-board-tickets", "morrow:ensure-overnight-board-tickets",
       "morrow:move-overnight-board-ticket", "morrow:add-overnight-board-ticket",
@@ -294,6 +298,7 @@ async function installSyntheticIpc(electronApp, fixture) {
     ipcMain.handle("morrow:bootstrap", () => clone(bootstrap()));
     ipcMain.handle("morrow:overnight-snapshot", () => clone(orchestration()));
     ipcMain.handle("morrow:refresh-daily-context", () => clone(orchestration()));
+    ipcMain.handle("morrow:refresh-overnight-providers", () => clone(orchestration()));
     ipcMain.handle("morrow:prepare-overnight-portfolio", () => clone(orchestration()));
     ipcMain.handle("morrow:open-conversation", () => clone(state().conversation));
     ipcMain.handle("morrow:start-conversation", () => clone(state().conversation));
@@ -415,7 +420,7 @@ function fixtureFor(command) {
       { provider: "claude", label: "Claude Code", status: "ready", authentication: "signed_in" },
       { provider: "codex", label: "Codex", status: "ready", authentication: "signed_out" },
       { provider: "grok", label: "Grok Build", status: "ready", authentication: "signed_in" },
-      { provider: "pi", label: "Pi Agent", status: "blocked", reason: "Morrow's conversation SDK is not an Overnight worker." },
+      { provider: "pi", label: "Pi Agent", status: "blocked", reason: "Pi Agent Overnight execution is not wired up yet." },
     ],
     context: {
       date: now.slice(0, 10),


### PR DESCRIPTION
## Finish condition

`drive.mjs` Settings CLI recipe waits for the live re-check, then accepts `Overnight hookup in progress` or `Not installed` for Pi, and does not require the old `Not ready for Overnight` / conversation-SDK copy.

## What changed

Verify feature files and the synthetic Settings driver match the current Overnight CLI statuses: Checking while a re-check runs, Couldn't check, Copy install for a missing pi CLI, and Pi as Overnight hookup in progress.

No product UI in this PR. Recipe-only.