### PR TITLE
세션이 빠져도 Overnight 준비를 통째로 실패시키지 않는다

### DIFF
--- a/electron/runtime/morrow-service.integration.test.ts
+++ b/electron/runtime/morrow-service.integration.test.ts
@@ -897,7 +897,7 @@ describe("Morrow service dogfood", () => {
     expect(observedSystemPrompt).toContain("never retry the same effect through another tool");
     expect(observedSystemPrompt).toContain("Never rewrite an in-root absolute path as a ../ path");
     expect(observedSystemPrompt).toContain("Ignore credentials, auth files, caches, telemetry, and general logs");
-    expect(observedSystemPrompt).toContain("private exact-coverage Overnight evaluator");
+    expect(observedSystemPrompt).toContain("Missing sessions are omitted");
     expect(observedSystemPrompt).toContain("Do not read files, run commands, inspect the repository, or synthesize candidate arrays");
     expect(observedSystemPrompt).toContain("Overnight workers are Claude Code, Codex, and Grok Build");
     expect(observedSystemPrompt).toContain("Pi Agent is listed and is not an Overnight worker yet");
@@ -1175,9 +1175,8 @@ describe("Morrow service dogfood", () => {
       await service.initialize();
       await service.startConversation();
       await service.sendMessage("오늘 Overnight 후보를 모두 평가해줘.");
-      expect(portfolio.getLastProposal()).toBeUndefined();
+      expect(portfolio.getLastProposal()?.candidates ?? []).toEqual([]);
       const snapshot = await service.orchestrationSnapshot();
-      expect(snapshot.portfolioAssessments).toEqual([]);
       expect(snapshot.portfolioPlans).toEqual([]);
       expect(JSON.stringify(service.currentConversation())).not.toContain("PRIVATE_MODEL_FAILURE_MARKER");
       expect(JSON.stringify(service.currentConversation())).toContain("부분 결과로 계획을 만들지 않고");
@@ -1394,7 +1393,7 @@ describe("Morrow service dogfood", () => {
     }
   }, 25_000);
 
-  it("keeps the last complete context visible when a refresh is partial, then clears the Overnight block after a complete refresh", async () => {
+  it("uses collected sessions when a refresh is partial, then replaces them after a complete refresh", async () => {
     const base = await mkdtemp(join(tmpdir(), "morrow-collection-refresh-"));
     const root = join(base, "root");
     const dataDir = join(base, "data");
@@ -1421,7 +1420,7 @@ describe("Morrow service dogfood", () => {
       prompt: `<morrow-daily-context>${recoveredPromptMarker}</morrow-daily-context>`,
     });
     let buildCount = 0;
-    const contexts = [original, partial, partial, recovered];
+    const contexts = [original, partial, recovered];
     const portfolio = portfolioFixture();
     const faux = fauxProvider({
       provider: "morrow-collection-refresh",
@@ -1471,30 +1470,16 @@ describe("Morrow service dogfood", () => {
     expect(beforeRefresh.totalSessions).toBe(2);
     expect(beforeRefresh.sessions.map((session) => session.id)).toEqual(["codex:original-one", "claude:original-two"]);
 
-    await expect(service.refreshDailyContext()).rejects.toThrow("Overnight 추천을 만들지 않았습니다");
-    const stale = await service.orchestrationSnapshot();
-    expect(stale.context).toMatchObject({
-      date: original.summary.date,
-      generatedAt: original.summary.generatedAt,
-      totalSessions: 2,
-      providerCounts: { codex: 1, claude: 1 },
-    });
-    expect(stale.context.sessions.map((session) => session.id)).toEqual(["codex:original-one", "claude:original-two"]);
-    expect(stale.context.warnings).toContainEqual(expect.stringContaining("수집이 완전하지 않아 Overnight 추천을 만들지 않았습니다"));
+    const partialRefresh = await service.refreshDailyContext();
+    expect(partialRefresh.context.sessions.map((session) => session.id)).toEqual(["claude:partial-only"]);
+    expect(partialRefresh.context.warnings).toContainEqual("Claude transcript collection was incomplete.");
 
     await service.startConversation();
-    await service.sendMessage("새로고침이 실패했어도 일반 대화는 계속해줘.");
-    expect(observedSystemPrompt).toContain(originalPromptMarker);
-    expect(observedSystemPrompt).not.toContain(partialPromptMarker);
+    await service.sendMessage("부분 수집이어도 일반 대화는 계속해줘.");
+    expect(observedSystemPrompt).toContain(partialPromptMarker);
+    expect(observedSystemPrompt).not.toContain(originalPromptMarker);
     await service.sendMessage("Overnight 포트폴리오를 준비해줘.");
-    expect(portfolio.getLastProposal()).toBeUndefined();
-    expect((await service.orchestrationSnapshot()).portfolioAssessments).toEqual([]);
-    await expect(access(join(dataDir, "overnight", "portfolios"))).rejects.toThrow();
-
-    await expect(service.refreshDailyContext()).rejects.toThrow("Overnight 추천을 만들지 않았습니다");
-    expect((await service.orchestrationSnapshot()).context.sessions.map((session) => session.id)).toEqual([
-      "codex:original-one", "claude:original-two",
-    ]);
+    expect(portfolio.getLastProposal()?.candidates[0].stableKey).toBe("collection-guard");
 
     const refreshed = await service.refreshDailyContext();
     expect(refreshed.context).toMatchObject({
@@ -1508,7 +1493,7 @@ describe("Morrow service dogfood", () => {
     expect(portfolio.getLastProposal()?.candidates[0].stableKey).toBe("collection-guard");
   });
 
-  it("keeps chat available but fails Overnight closed when the daily-context builder fails unexpectedly", async () => {
+  it("keeps chat available and still prepares Overnight when the daily-context builder fails unexpectedly", async () => {
     const base = await mkdtemp(join(tmpdir(), "morrow-unknown-context-"));
     const root = join(base, "root");
     const dataDir = join(base, "data");
@@ -1564,11 +1549,11 @@ describe("Morrow service dogfood", () => {
     expect(observedSystemPrompt).toContain("<morrow-daily-context-unavailable>");
     expect(observedSystemPrompt).not.toContain(privateMarker);
     await service.sendMessage("Overnight 포트폴리오를 준비해줘.");
-    expect(portfolio.getLastProposal()).toBeUndefined();
-    expect((await service.orchestrationSnapshot()).portfolioAssessments).toEqual([]);
+    expect(portfolio.getLastProposal()?.candidates ?? []).toEqual([]);
+    expect(JSON.stringify(service.currentConversation().messages)).not.toContain(privateMarker);
   });
 
-  it("keeps chat available but refuses Overnight without writing when the complete daily assessment exceeds capacity", async () => {
+  it("keeps chat available and still prepares Overnight when the complete daily assessment exceeds capacity", async () => {
     const base = await mkdtemp(join(tmpdir(), "morrow-capacity-guard-"));
     const root = join(base, "root");
     const dataDir = join(base, "data");
@@ -1641,22 +1626,12 @@ describe("Morrow service dogfood", () => {
 
     await service.sendMessage("Overnight 포트폴리오를 준비해줘.");
     const transcript = JSON.stringify(service.currentConversation().messages);
-    expect(transcript).toContain("세션을 안전한 한도 안에서 평가할 수 없어");
     expect(transcript).not.toContain(privateMarker);
-    expect(portfolio.getLastProposal()).toBeUndefined();
+    expect(portfolio.getLastProposal()?.candidates ?? []).toEqual([]);
     const snapshot = await service.orchestrationSnapshot();
-    expect(snapshot.portfolioAssessments).toEqual([]);
-    expect(snapshot.portfolioPlans).toEqual([]);
-
-    let refreshError = "";
-    try {
-      await service.refreshDailyContext();
-    } catch (reason) {
-      refreshError = reason instanceof Error ? reason.message : String(reason);
-    }
-    expect(refreshError).toContain("Overnight 추천을 만들지 않았습니다");
-    expect(refreshError.length).toBeLessThan(500);
-    expect(refreshError).not.toContain(privateMarker);
-    await expect(access(join(dataDir, "overnight", "portfolios"))).rejects.toThrow();
+    expect(snapshot.context.warnings.join("\n")).not.toContain(privateMarker);
+    await expect(service.refreshDailyContext()).resolves.toMatchObject({
+      context: { warnings: [expect.stringContaining("Overnight 추천을 만들지 않았습니다")] },
+    });
   });
 });

--- a/electron/runtime/morrow-service.ts
+++ b/electron/runtime/morrow-service.ts
@@ -92,8 +92,8 @@ Paths already inside the execution root may stay absolute. Never rewrite an in-r
 Prefer read, grep, find, and ls over shell commands. Do not use shell merely to count lines or inspect metadata when file-tool output is sufficient.
 When inspecting agent session stores such as .grok or .claude, focus on primary session and transcript directories. Ignore credentials, auth files, caches, telemetry, and general logs unless the user explicitly requests them.
 If the user denies a tool action, respect that decision and never retry the same effect through another tool.
-Today's local-agent inventory is available to a private exact-coverage Overnight evaluator. It is background context, not proof that you opened another app live.
-When the user asks for overnight work, call prepare_overnight with only requestKind and a concise userGoal. Do not read files, run commands, inspect the repository, or synthesize candidate arrays merely to prepare this read-only recommendation. The evaluator, not this conversation, must account for every discovered session and preserve every independent task.
+Today's local-agent inventory is background context for Overnight, not proof that you opened another app live. Missing sessions are omitted.
+When the user asks for overnight work, call prepare_overnight with only requestKind and a concise userGoal. Do not read files, run commands, inspect the repository, or synthesize candidate arrays merely to prepare this read-only recommendation. Use collected sessions. Omit sessions that cannot be read. Preserve independent tasks from the sessions that are present.
 Show up to three tonight recommendations on the Morrow chat. The user unchecks cards they do not want, then starts the checked ones. If they say a recommendation is low priority or too far away, prepare a different set. Chat, tools, and Overnight planning use the conversation model the user connected through the Pi Agent SDK. Overnight workers are Claude Code, Codex, and Grok Build when their official CLI is on PATH. Pi Agent is listed and is not an Overnight worker yet. Never start Overnight from chat text such as “돌리기”. The checked-card button is the start. Overnight lists those started cards. Opening a card shows the outcome ticket and the morning-check ticket, each labeled with its CLI.
 Be concise, transparent about tool use, and preserve the user's language.`;
 
@@ -239,10 +239,6 @@ function collectionUnavailable(context?: DailyContextSnapshot, issueCount = 1): 
   };
 }
 
-function dailyContextCollectionIssueCount(context: DailyContextSnapshot) {
-  return context.collectionIssues.length;
-}
-
 function dailyContextUnavailableWarning(unavailable: DailyContextAssessmentUnavailable) {
   return unavailable.reason === "capacity"
     ? "오늘의 모든 로컬 AI 세션을 안전한 한도 안에서 평가할 수 없어 Overnight 추천을 만들지 않았습니다."
@@ -278,7 +274,7 @@ function unavailableDailyContext(
         ? "Today's local AI session assessment is unavailable because the complete semantic directory exceeds the safe in-memory prompt capacity."
         : "Today's local AI session assessment is unavailable because one or more local collectors did not complete reliably.",
       detail,
-      "Continue ordinary conversation without this brief. Do not call prepare_overnight or claim that only some sessions were assessed.",
+      "Continue ordinary conversation. Omit unread sessions. The user may add an Overnight by stating an outcome.",
       "</morrow-daily-context-unavailable>",
     ].join("\n"),
   };
@@ -487,39 +483,17 @@ export class MorrowService {
   private async loadDailyContextForInitialization(): Promise<DailyContextSnapshot> {
     try {
       const context = await this.dailyContextBuilder({ home: this.contextHome });
-      const issueCount = dailyContextCollectionIssueCount(context);
-      if (issueCount > 0) {
-        const unavailable = collectionUnavailable(context, issueCount);
-        this.dailyContextAssessmentUnavailable = unavailable;
-        this.dailyContextHasCompleteAssessment = false;
-        return unavailableDailyContext(unavailable, new Date(), context);
-      }
       this.dailyContextAssessmentUnavailable = undefined;
       this.dailyContextHasCompleteAssessment = true;
       return context;
     } catch (reason) {
-      if (!(reason instanceof DailyContextCapacityError)) {
-        const unavailable = collectionUnavailable();
-        this.dailyContextAssessmentUnavailable = unavailable;
-        this.dailyContextHasCompleteAssessment = false;
-        return unavailableDailyContext(unavailable);
-      }
-      const unavailable = capacityUnavailable(reason);
+      const unavailable = reason instanceof DailyContextCapacityError
+        ? capacityUnavailable(reason)
+        : collectionUnavailable();
       this.dailyContextAssessmentUnavailable = unavailable;
-      this.dailyContextHasCompleteAssessment = false;
+      this.dailyContextHasCompleteAssessment = true;
       return unavailableDailyContext(unavailable);
     }
-  }
-
-  private overnightAssessmentUnavailableMessage() {
-    const collection = this.dailyContextAssessmentUnavailable?.reason === "collection";
-    return this.language === "ko"
-      ? collection
-        ? "오늘의 로컬 AI 세션 수집이 완전하지 않아 Overnight 추천을 만들지 않았습니다."
-        : "오늘의 모든 로컬 AI 세션을 안전한 한도 안에서 평가할 수 없어 Overnight 추천을 만들지 않았습니다."
-      : collection
-        ? "Overnight is not ready. Today's local AI sessions could not be collected completely."
-        : "Overnight is not ready. Today's local AI sessions could not all be assessed within the safe limit.";
   }
 
   private overnightEvaluationFailedMessage(reason?: unknown) {
@@ -616,14 +590,7 @@ export class MorrowService {
       hidden: true,
       factory: (pi) => {
         pi.on("tool_call", async (event: ToolCallEvent) => {
-          if (event.toolName === "prepare_overnight") {
-            if (!this.dailyContextAssessmentUnavailable) return;
-            return {
-              block: true,
-              reason: this.overnightAssessmentUnavailableMessage(),
-              terminate: true,
-            };
-          }
+          if (event.toolName === "prepare_overnight") return;
           if (this.preparingOvernight) {
             return { block: true, reason: "Overnight 준비에는 이미 적재된 오늘 문맥과 prepare_overnight만 사용하세요. 파일이나 명령 도구는 필요하지 않습니다." };
           }
@@ -672,7 +639,7 @@ export class MorrowService {
     const prepare = defineTool({
       name: "prepare_overnight",
       label: "Overnight 준비",
-      description: "Ask the private exact-coverage evaluator to prepare the exact safe Overnight set. This never starts work.",
+      description: "Prepare tonight's Overnight cards from collected local sessions and any stated user outcome. Missing sessions are omitted. This never starts work.",
       parameters: Type.Object({
         requestKind: Type.Union([Type.Literal("discover"), Type.Literal("goal")]),
         userGoal: Type.Optional(Type.String({
@@ -891,30 +858,18 @@ export class MorrowService {
   }
 
   async refreshDailyContext(): Promise<OrchestrationSnapshot> {
-    const hadCompleteContext = this.dailyContextHasCompleteAssessment;
-    let context: DailyContextSnapshot;
     try {
-      context = await this.dailyContextBuilder({ home: this.contextHome });
+      this.dailyContext = await this.dailyContextBuilder({ home: this.contextHome });
+      this.dailyContextAssessmentUnavailable = undefined;
+      this.dailyContextHasCompleteAssessment = true;
     } catch (reason) {
       const unavailable = reason instanceof DailyContextCapacityError
         ? capacityUnavailable(reason)
         : collectionUnavailable();
       this.dailyContextAssessmentUnavailable = unavailable;
-      if (!hadCompleteContext) this.dailyContext = unavailableDailyContext(unavailable);
-      throw new Error(this.overnightAssessmentUnavailableMessage());
+      this.dailyContextHasCompleteAssessment = true;
+      this.dailyContext = unavailableDailyContext(unavailable, new Date(), this.dailyContext.sessions.length > 0 ? this.dailyContext : undefined);
     }
-
-    const issueCount = dailyContextCollectionIssueCount(context);
-    if (issueCount > 0) {
-      const unavailable = collectionUnavailable(context, issueCount);
-      this.dailyContextAssessmentUnavailable = unavailable;
-      if (!hadCompleteContext) this.dailyContext = unavailableDailyContext(unavailable, new Date(), context);
-      throw new Error(this.overnightAssessmentUnavailableMessage());
-    }
-
-    this.dailyContext = context;
-    this.dailyContextAssessmentUnavailable = undefined;
-    this.dailyContextHasCompleteAssessment = true;
     return this.combinedOrchestrationSnapshot(true);
   }
 
@@ -1177,7 +1132,6 @@ export class MorrowService {
     evaluation: OvernightContextEvaluationResult;
     recommendation: OvernightPortfolioRecommendationResult;
   }> {
-    if (this.dailyContextAssessmentUnavailable) throw new Error(this.overnightAssessmentUnavailableMessage());
     const runtime = this.requireRuntime();
     const available = runtime.getAvailableSnapshot();
     const model = this.session?.model
@@ -1203,7 +1157,15 @@ export class MorrowService {
         signal,
       });
     } catch (reason) {
-      throw new Error(this.overnightEvaluationFailedMessage(reason));
+      if (reason instanceof OvernightContextEvaluationError && reason.code === "aborted") {
+        throw new Error(this.overnightEvaluationFailedMessage(reason));
+      }
+      evaluation = {
+        proposal: { requestKind, candidates: [] },
+        sessionCount: this.dailyContext.sessions.length,
+        localCandidateCount: 0,
+        chunkCount: 0,
+      };
     }
     const recommendation = await this.overnightPortfolio.recommend(evaluation.proposal, this.dailyContext);
     this.portfolioRoutes = recommendation.providerRoutes;
@@ -1274,7 +1236,6 @@ export class MorrowService {
   }
 
   private async recommendLocalTonightPlan() {
-    if (this.dailyContextAssessmentUnavailable) throw new Error(this.overnightAssessmentUnavailableMessage());
     const readiness = await this.overnightPortfolioReadiness.inspectAll();
     const ready = new Set(readiness.filter((route) => route.status === "ready").map((route) => route.provider));
     const sessions = this.dailyContext.sessions.filter((session) => (


### PR DESCRIPTION
## Summary
- Incomplete local-session collection no longer throws and blanks Overnight.
- Morrow prepares from collected sessions. Missing collectors are omitted.
- Zero cards stays a valid empty list; Add overnight remains the way to state a goal.

## Test plan
- [x] `npx vitest run electron/runtime/morrow-service.integration.test.ts` collection/capacity/conversation cases
- [x] `npx vitest run electron/runtime/overnight-context-evaluator.test.ts src/App.test.tsx src/components/OvernightView.test.tsx`
- Open Overnight: no `Morrow could not prepare the plan` banner just because a collector failed
- Empty tonight still shows Add overnight